### PR TITLE
make jrl-cmake path-independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 2.8)
+project(jrl-cmake NONE)
+if(UNIX)
+  set(_install_dest
+    ${CMAKE_INSTALL_PREFIX}/share/cmake
+  )
+else()
+  # No need to try /usr/local/share/
+  # on windows:
+  set(_install_dest
+    ${CMAKE_ROOT}/Modules
+  )
+endif()
+
+# list of files to install: all executable files
+# Hint: keep this list up-to-date using
+# git ls-tree -r HEAD | grep "^100755" | cut -f 2
+set(_programs
+bootstrap
+compile.py
+git-archive-all.sh
+github/update-doxygen-doc.sh
+)
+
+# list of files to install: all but CMakeLists.txt and executable ones
+# we cannot install the whole directory or a glob because that would install
+# the build directory too if it happens to be inside the source directory.
+# Hint: keep this list up-to-date using
+# git ls-tree -r HEAD | grep "^100644" | cut -f 2 | grep -v CMakeLists.txt
+set(_files
+FindOpenRTM.cmake
+README.md
+base.cmake
+boost.cmake
+cmake_uninstall.cmake.in
+compiler.cmake
+config.h.cmake
+config.hh.cmake
+cpack.cmake
+createshexe.cmake
+debian.cmake
+deprecated.hh.cmake
+dist.cmake
+distcheck.cmake
+doxygen.cmake
+doxygen/Doxyfile.in
+doxygen/doxygen.css
+doxygen/footer.html
+doxygen/header.html
+doxygen/header.tex
+doxygen/style.rtf
+doxygen/style.tex
+doxygen/tabs.css
+dynamic_graph/python-module-py.cc
+dynamic_graph/submodule/__init__.py.cmake
+eigen.cmake
+header.cmake
+idl.cmake
+idlrtc.cmake
+image/visp.cmake
+install-data.cmake
+jrl-cmake-config.cmake
+kineo.cmake
+lapack.cmake
+logging.cmake
+man.cmake
+openhrpcontroller.cmake
+openrtm.cmake
+pkg-config.cmake
+pkg-config.pc.cmake
+portability.cmake
+pthread.cmake
+python.cmake
+release.cmake
+ros.cmake
+shared-library.cmake
+sphinx.cmake
+sphinx/conf.py.in
+sphinx/index.rst.in
+test.cmake
+uninstall.cmake
+version.cmake
+warning.hh.cmake
+)
+foreach(_file ${_programs})
+  get_filename_component(_subdir ${_file} PATH)
+  install(
+    PROGRAMS  ${_file}
+    DESTINATION "${_install_dest}/${PROJECT_NAME}/${_subdir}")
+endforeach()
+foreach(_file ${_files})
+  get_filename_component(_subdir ${_file} PATH)
+  install(
+  FILES ${_file}
+  DESTINATION "${_install_dest}/${PROJECT_NAME}/${_subdir}")
+endforeach()

--- a/base.cmake
+++ b/base.cmake
@@ -42,20 +42,32 @@
 # - unit tests should be tagged as
 #   EXCLUDE_FROM_ALL and make test should trigger their compilation.
 
+# ensure jrl-cmake_DIR is set
+IF(NOT DEFINED jrl-cmake_DIR)
+    # user has probably not done
+    #   FIND_PACKAGE(jrl-cmake HINTS cmake)
+    #   INCLUDE(${jrl-cmake_DIR}/base.cmake)
+    # which sets the variable, but directly
+    #   INCLUDE(cmake/base.cmake)
+    # So let set it
+    GET_FILENAME_COMPONENT(_path ${CMAKE_CURRENT_LIST_FILE} PATH)
+    SET(jrl-cmake_DIR "${_path}" CACHE PATH "jrl-cmake install path")
+ENDIF(NOT DEFINED jrl-cmake_DIR)
+
 # Include base features.
-INCLUDE(cmake/logging.cmake)
-INCLUDE(cmake/portability.cmake)
-INCLUDE(cmake/compiler.cmake)
-INCLUDE(cmake/debian.cmake)
-INCLUDE(cmake/dist.cmake)
-INCLUDE(cmake/distcheck.cmake)
-INCLUDE(cmake/doxygen.cmake)
-INCLUDE(cmake/header.cmake)
-INCLUDE(cmake/pkg-config.cmake)
-INCLUDE(cmake/uninstall.cmake)
-INCLUDE(cmake/install-data.cmake)
-INCLUDE(cmake/release.cmake)
-INCLUDE(cmake/version.cmake)
+INCLUDE(${jrl-cmake_DIR}/logging.cmake)
+INCLUDE(${jrl-cmake_DIR}/portability.cmake)
+INCLUDE(${jrl-cmake_DIR}/compiler.cmake)
+INCLUDE(${jrl-cmake_DIR}/debian.cmake)
+INCLUDE(${jrl-cmake_DIR}/dist.cmake)
+INCLUDE(${jrl-cmake_DIR}/distcheck.cmake)
+INCLUDE(${jrl-cmake_DIR}/doxygen.cmake)
+INCLUDE(${jrl-cmake_DIR}/header.cmake)
+INCLUDE(${jrl-cmake_DIR}/pkg-config.cmake)
+INCLUDE(${jrl-cmake_DIR}/uninstall.cmake)
+INCLUDE(${jrl-cmake_DIR}/install-data.cmake)
+INCLUDE(${jrl-cmake_DIR}/release.cmake)
+INCLUDE(${jrl-cmake_DIR}/version.cmake)
 
  # --------- #
  # Constants #

--- a/dist.cmake
+++ b/dist.cmake
@@ -29,7 +29,7 @@ MACRO(_SETUP_PROJECT_DIST)
 
     ADD_CUSTOM_TARGET(distdir
       COMMAND
-      ${CMAKE_SOURCE_DIR}/cmake/git-archive-all.sh
+      ${jrl-cmake_DIR}/git-archive-all.sh
       --prefix ${PROJECT_NAME}-${PROJECT_VERSION}/  ${PROJECT_NAME}.tar
       && cd ${CMAKE_BINARY_DIR}/
       && (test -d ${PROJECT_NAME}-${PROJECT_VERSION}

--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -126,7 +126,7 @@ MACRO(_SETUP_PROJECT_DOCUMENTATION_FINALIZE)
     )
   # Generate Doxyfile.
   CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/doxygen/Doxyfile.in
+    ${jrl-cmake_DIR}/doxygen/Doxyfile.in
     ${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile
     @ONLY
     )

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -798,13 +798,13 @@ HTML_FILE_EXTENSION    = .html
 # each generated HTML page. If it is left blank doxygen will generate a
 # standard header.
 
-HTML_HEADER            = @CMAKE_SOURCE_DIR@/cmake/doxygen/header.html
+HTML_HEADER            = @jrl-cmake_DIR@/doxygen/header.html
 
 # The HTML_FOOTER tag can be used to specify a personal HTML footer for
 # each generated HTML page. If it is left blank doxygen will generate a
 # standard footer.
 
-HTML_FOOTER            = @CMAKE_SOURCE_DIR@/cmake/doxygen/footer.html
+HTML_FOOTER            = @jrl-cmake_DIR@/doxygen/footer.html
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading
 # style sheet that is used by each HTML page. It can be used to
@@ -813,7 +813,7 @@ HTML_FOOTER            = @CMAKE_SOURCE_DIR@/cmake/doxygen/footer.html
 # the style sheet file to the HTML output directory, so don't put your own
 # stylesheet in the HTML output directory as well, or it will be erased!
 
-HTML_STYLESHEET        = @CMAKE_SOURCE_DIR@/cmake/doxygen/doxygen.css
+HTML_STYLESHEET        = @jrl-cmake_DIR@/doxygen/doxygen.css
 
 # If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
 # page will contain the date and time when the page was generated. Setting

--- a/header.cmake
+++ b/header.cmake
@@ -71,7 +71,7 @@ MACRO(_SETUP_PROJECT_HEADER)
 
   # Generate deprecated.hh header.
   CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/deprecated.hh.cmake
+    ${jrl-cmake_DIR}/deprecated.hh.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/deprecated.hh
     @ONLY
     )
@@ -81,7 +81,7 @@ MACRO(_SETUP_PROJECT_HEADER)
     )
   # Generate warning.hh header.
   CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/warning.hh.cmake
+    ${jrl-cmake_DIR}/warning.hh.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/warning.hh
     @ONLY
     )
@@ -97,7 +97,7 @@ MACRO(_SETUP_PROJECT_HEADER)
   # in the top-level directory of the build tree.
   # Therefore it must not be inluded by any distributed header.
   CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.cmake
+    ${jrl-cmake_DIR}/config.h.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/config.h
     )
   INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
@@ -129,7 +129,7 @@ ENDMACRO(_SETUP_PROJECT_HEADER)
 FUNCTION(GENERATE_CONFIGURATION_HEADER HEADER_DIR FILENAME LIBRARY_NAME EXPORT_SYMBOL)
   # Generate the header.
   CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.hh.cmake
+      ${jrl-cmake_DIR}/config.hh.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/${FILENAME}
     @ONLY
     )

--- a/jrl-cmake-config.cmake
+++ b/jrl-cmake-config.cmake
@@ -1,0 +1,2 @@
+# nothing to do here. This file will be found by find_package, which
+# will set jrl-make_DIR to the directory containing it.

--- a/openhrpcontroller.cmake
+++ b/openhrpcontroller.cmake
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # OpenRTM-aist
-INCLUDE(cmake/openrtm.cmake)
+INCLUDE(${jrl-cmake_DIR}/openrtm.cmake)
 
 macro(create_simple_controller CONTROLLER_NAME)
   openrtm()

--- a/pkg-config.cmake
+++ b/pkg-config.cmake
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-INCLUDE(cmake/shared-library.cmake)
+INCLUDE(${jrl-cmake_DIR}/shared-library.cmake)
 
 FIND_PACKAGE(PkgConfig)
 
@@ -95,7 +95,7 @@ ENDMACRO(_SETUP_PROJECT_PKG_CONFIG)
 MACRO(_SETUP_PROJECT_PKG_CONFIG_FINALIZE)
   # Generate the pkg-config file.
   CONFIGURE_FILE(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkg-config.pc.cmake"
+    "${jrl-cmake_DIR}/pkg-config.pc.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
     )
 ENDMACRO(_SETUP_PROJECT_PKG_CONFIG_FINALIZE)

--- a/python.cmake
+++ b/python.cmake
@@ -59,7 +59,7 @@ MACRO(DYNAMIC_GRAPH_PYTHON_MODULE SUBMODULENAME LIBRARYNAME TARGETNAME)
 
   ADD_LIBRARY(${PYTHON_MODULE}
     MODULE
-    ${CMAKE_SOURCE_DIR}/cmake/dynamic_graph/python-module-py.cc)
+    ${jrl-cmake_DIR}/dynamic_graph/python-module-py.cc)
 
   FILE(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/src/dynamic_graph/${SUBMODULENAME})
   SET_TARGET_PROPERTIES(${PYTHON_MODULE}
@@ -86,7 +86,7 @@ MACRO(DYNAMIC_GRAPH_PYTHON_MODULE SUBMODULENAME LIBRARYNAME TARGETNAME)
   ENDFOREACH(ENTITY ${NEW_ENTITY_CLASS})
 
   CONFIGURE_FILE(
-    ${CMAKE_SOURCE_DIR}/cmake/dynamic_graph/submodule/__init__.py.cmake
+    ${jrl-cmake_DIR}/dynamic_graph/submodule/__init__.py.cmake
     ${CMAKE_BINARY_DIR}/src/dynamic_graph/${SUBMODULENAME}/__init__.py
     )
 
@@ -110,7 +110,7 @@ MACRO(PYTHON_INSTALL MODULE FILE DEST)
   INSTALL(CODE
     "EXEC_PROGRAM(
     \"${PYTHON_EXECUTABLE}\" ARGS
-    \"${CMAKE_SOURCE_DIR}/cmake/compile.py\"
+    \"${jrl-cmake_DIR}/compile.py\"
     \"${CMAKE_CURRENT_SOURCE_DIR}\"
     \"${CMAKE_CURRENT_BINARY_DIR}\"
     \"${MODULE}/${FILE}\")
@@ -159,7 +159,7 @@ MACRO(PYTHON_INSTALL_BUILD MODULE FILE DEST)
   INSTALL(CODE
     "EXEC_PROGRAM(
     \"${PYTHON_EXECUTABLE}\" ARGS
-    \"${CMAKE_SOURCE_DIR}/cmake/compile.py\"
+    \"${jrl-cmake_DIR}/compile.py\"
     \"${CMAKE_CURRENT_BINARY_DIR}\"
     \"${CMAKE_CURRENT_BINARY_DIR}\"
     \"${MODULE}/${FILE}\")

--- a/uninstall.cmake
+++ b/uninstall.cmake
@@ -22,7 +22,7 @@ MACRO(_SETUP_PROJECT_UNINSTALL)
   # FIXME: it is utterly stupid to rely on the install manifest.
   # Can't we just remember what we install ?!
   CONFIGURE_FILE(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+    "${jrl-cmake_DIR}/cmake_uninstall.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
     IMMEDIATE
     @ONLY


### PR DESCRIPTION
currently users install jrl-cmake in the "cmake" subdirectory of their
project and do:

  INCLUDE(cmake/base.cmake)

with this commit, they can install jrl-cmake system-wide and then do:

  FIND_PACKAGE(jrl-cmake REQUIRED HINTS cmake)
  INCLUDE(${jrl-cmake_DIR}/base.cmake)

The jrl-cmake package will be searched for at standard locations
(/usr/local/share/cmake/jrl-cmake/, in toolchains, see the find_package
documentation for more details) and in the "cmake" subdirectory, as usual.
A user can also directly set the jrl-cmake_DIR variable, find_package will
use it (and not overwrite it).

Note that doing

  INCLUDE(cmake/base.cmake)

is still ok, since base.cmake will set jrl-cmake_DIR when needed.

This feature lets jrl-cmake be handled (packaged, installed) just like
any dependency. In particular, it enables users to not use the git
submodule (just install jrl-cmake system-wide and do not init the submodule)
which is important for buildfarms with flacky connection to the Internet.

This commit also adds install rules for jrl-cmake. To install jrl-cmake in
/usr/local/share/cmake/jrl-cmake/, just do

  git clone https://github.com/jrl-umi3218/jrl-cmakemodules.git
  cd jrl-cmakemodules
  mkdir build
  cd build
  cmake ..
  sudo make install

epilog: I checked it works when installed system-wide and otherwise, but my test did not cover much of the feature set since I do not use much of them (I cannot guarantee that, say doxygen still works).
