### PR TITLE
Enable PYTHON_DEB_LAYOUT option if using a debian flavored distro

### DIFF
--- a/python.cmake
+++ b/python.cmake
@@ -33,6 +33,9 @@ SET(PYTHON_PACKAGES_DIR site-packages)
 
 # Use either site-packages (default) or dist-packages (Debian packages) directory
 OPTION(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
+IF(EXISTS "/etc/debian_version")
+  SET(PYTHON_DEB_LAYOUT ON)
+ENDIF()
 
 IF (PYTHON_DEB_LAYOUT)
   SET(PYTHON_PACKAGES_DIR dist-packages)


### PR DESCRIPTION
Following the issue discussed in #38 I think it makes sense to enable the PYTHON_DEB_LAYOUT option by default when using a debian-flavored distribution. This makes it significantly easier to work with catkin for example.

Maybe there was a reason why this was not done in the first place? (cc @bchretien)
