### PR TITLE
Fix CMP0007 policy problem + .catkin removal in case of catkin package.

### DIFF
--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -14,10 +14,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # This files comes from the CMake FAQ: http://www.cmake.org/Wiki/CMake_FAQ
-
+cmake_policy(SET CMP0007 OLD)
 IF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
   MESSAGE(FATAL_ERROR "Cannot find install manifest:\"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
 ENDIF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+MESSAGE(STATUS "catkin path: @CMAKE_INSTALL_PREFIX@/.catkin")
+IF(EXISTS "@CMAKE_INSTALL_PREFIX@/.catkin")
+  MESSAGE(STATUS "Try to remove @CMAKE_INSTALL_PREFIX@/.catkin")
+  EXECUTE_PROCESS(
+      COMMAND @CMAKE_COMMAND@ -E remove "@CMAKE_INSTALL_PREFIX@/.catkin"
+      RESULT_VARIABLE rm_resval
+      OUTPUT_VARIABLE rm_out
+      ERROR_VARIABLE rm_err
+       )
+ENDIF(EXISTS "@CMAKE_INSTALL_PREFIX@/.catkin")
+
 
 FILE(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
 STRING(REGEX REPLACE "\n" ";" files "${files}")


### PR DESCRIPTION
This commit fix a problem when a package is both a jrl-cmakemodules package and a catkin
package (see dynamic_graph_bridge_msgs).
This fix a CMP0007 policy problem, and remove the .catkin file put in the _inst directory during distcheck.
The file is not in the list of installed_files and is not removed, making the test for proper uninstall failed.
