### PR TITLE
Doxygen stylesheet

### DIFF
--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -47,6 +47,12 @@ MACRO(_SETUP_PROJECT_DOCUMENTATION)
       SET(DOXYGEN_USE_MATHJAX "NO")
     ENDIF()
 
+    # HTML style sheet configuration
+    IF(NOT DEFINED DOXYGEN_USE_TEMPLATE_CSS)
+      SET(DOXYGEN_USE_TEMPLATE_CSS "NO")
+    ENDIF()
+
+
     # Teach CMake how to generate the documentation.
     IF(MSVC)
       # FIXME: it is impossible to trigger documentation installation
@@ -65,6 +71,27 @@ MACRO(_SETUP_PROJECT_DOCUMENTATION)
 
       INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_MAKE_PROGRAM} doc)")
     ENDIF(MSVC)
+
+    IF (DOXYGEN_USE_TEMPLATE_CSS)
+      ADD_CUSTOM_COMMAND(
+        OUTPUT
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/header.html
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/footer.html
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/doxygen.css
+        COMMAND ${DOXYGEN_EXECUTABLE} -w html
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/header.html
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/footer.html
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/doxygen.css
+        WORKING_DIRECTORY doc
+        COMMENT "Generating Doxygen template files"
+        )
+    ELSE (DOXYGEN_USE_TEMPLATE_CSS)
+      FILE (COPY
+        ${PROJECT_SOURCE_DIR}/cmake/doxygen/doxygen.css
+        DESTINATION
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/
+        )
+    ENDIF (DOXYGEN_USE_TEMPLATE_CSS)
 
     ADD_CUSTOM_COMMAND(
       OUTPUT
@@ -111,6 +138,7 @@ MACRO(_SETUP_PROJECT_DOCUMENTATION)
       DOXYGEN_DOT_PATH
       DOXYGEN_DOT_IMAGE_FORMAT
       DOXYGEN_USE_MATHJAX
+      DOXYGEN_USE_TEMPLATE_CSS
       )
   ENDIF(NOT DOXYGEN_FOUND)
 ENDMACRO(_SETUP_PROJECT_DOCUMENTATION)

--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -49,9 +49,8 @@ MACRO(_SETUP_PROJECT_DOCUMENTATION)
 
     # HTML style sheet configuration
     IF(NOT DEFINED DOXYGEN_USE_TEMPLATE_CSS)
-      SET(DOXYGEN_USE_TEMPLATE_CSS "NO")
+      SET(DOXYGEN_USE_TEMPLATE_CSS "YES")
     ENDIF()
-
 
     # Teach CMake how to generate the documentation.
     IF(MSVC)

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -791,7 +791,7 @@ HTML_FOOTER            = @PROJECT_SOURCE_DIR@/cmake/doxygen/footer.html
 # the style sheet file to the HTML output directory, so don't put your own
 # stylesheet in the HTML output directory as well, or it will be erased!
 
-HTML_STYLESHEET        = @PROJECT_SOURCE_DIR@/cmake/doxygen/doxygen.css
+HTML_STYLESHEET        = @PROJECT_BINARY_DIR@/doc/doxygen.css
 
 # If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
 # page will contain the date and time when the page was generated. Setting


### PR DESCRIPTION
### Problem
As mentioned in the Doxygen manual (http://www.stack.nl/~dimitri/doxygen/manual/customize.html#minor_tweaks_header_css), the style sheet should not be passed with `HTML_STYLESHEET` but with `HTML_EXTRA_STYLESHEET`. Tag `HTML_STYLESHEET` produces conflicts between Doxygen versions.

### Proposed solution
To ensure backward compatibility, variable `DOXYGEN_USE_TEMPLATE_CSS` is introduced. When set to `TRUE`, the default Doxygen CSS is used instead of the one provided by this module (outdated on Ubuntu 14.04).
The variable defaults to `YES` and users willing to have backward compatibility should add `SET (DOXYGEN_USE_TEMPLATE_CSS NO)` to `CmakeLists.txt`.

### Cleaner solution
A cleaner solution would be to replace in `doxygen/Doxyfile.in` this line:
```HTML_STYLESHEET        = @PROJECT_BINARY_DIR@/doc/doxygen.css```
by
```HTML_STYLESHEET        =```
and to remove `doxygen/doxygen.css`
Users could add their own CSS by setting `HTML_EXTRA_STYLESHEET` in their `Doxyfile.extra`. I do not see any easy way of ensuring backward compatibility with this solution.