### PR TITLE
header.cmake: do not install config.h

### DIFF
--- a/header.cmake
+++ b/header.cmake
@@ -104,10 +104,6 @@ MACRO(_SETUP_PROJECT_HEADER)
     ${PROJECT_SOURCE_DIR}/cmake/config.h.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/config.h
     )
-  INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_DIR}
-    PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
-    )
 
   # Default include directories:
   # - top-level build directory (for generated non-distributed headers).


### PR DESCRIPTION
As the original comment explains, that header should not be installed (this is **not** `config.hh`):

```cmake
# Generate config.h header.
# This header, unlike the previous one is *not* installed and is generated
# in the top-level directory of the build tree.
# Therefore it must not be inluded by any distributed header.
```

This behavior was introduced in de268ce19d0526f6364ad60ecafc2bfeb7c77b72.