### PR TITLE
Can now generate standard CMake *Config.cmake and *Version.cmake files.

### DIFF
--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,4 +1,4 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")

--- a/base.cmake
+++ b/base.cmake
@@ -121,16 +121,16 @@ MACRO(_SETUP_PROJECT_PACKAGE_INIT)
 #   * <prefix>/lib/cmake/<PROJECT-NAME>
 #   * <prefix>/lib/
 #   * <prefix>/include/
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
-set(include_install_dir "include")
-set(include_install_destination "${include_install_dir}/${PROJECT_NAME}")
+set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(INCLUDE_INSTALL_DIR "include")
+set(INCLUDE_INSTALL_DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
 
-set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 # Configuration
-set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
-set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
-set(targets_export_name "${PROJECT_NAME}Targets")
+set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 ENDMACRO(_SETUP_PROJECT_PACKAGE_INIT)
 
@@ -232,16 +232,16 @@ MACRO(_SETUP_PROJECT_PACKAGE_FINALIZE)
 #   * <prefix>/lib/cmake/<PROJECT-NAME>
 #   * <prefix>/lib/
 #   * <prefix>/include/
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
-set(include_install_dir "include")
-set(include_install_destination "${include_install_dir}/${PROJECT_NAME}")
+set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(INCLUDE_INSTALL_DIR "include")
+set(INCLUDE_INSTALL_DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
 
-set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 # Configuration
-set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
-set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
-set(targets_export_name "${PROJECT_NAME}Targets")
+set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 
 # Include module with fuction 'write_basic_package_version_file'
@@ -250,66 +250,33 @@ include(CMakePackageConfigHelpers)
 # Configure '<PROJECT-NAME>ConfigVersion.cmake'
 # Note: PROJECT_VERSION is used as a VERSION
 write_basic_package_version_file(
-    "${version_config}" COMPATIBILITY SameMajorVersion
+    "${VERSION_CONFIG}" COMPATIBILITY SameMajorVersion
 )
 
 # Configure '<PROJECT-NAME>Config.cmake'
 # Use variables:
-#   * targets_export_name
+#   * TARGETS_EXPORT_NAME
 #   * PROJECT_NAME
 configure_package_config_file(
     "cmake/Config.cmake.in"
-    "${project_config}"
-    INSTALL_DESTINATION "${config_install_dir}"
+    "${PROJECT_CONFIG}"
+    INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
 )
-
-# # Targets:
-# #   * <prefix>/lib/libbar.a
-# #   * <prefix>/lib/libbaz.a
-# #   * header location after install: <prefix>/include/foo/Bar.hpp
-# #   * headers can be included by C++ code `#include <foo/Bar.hpp>`
-# install(
-#     TARGETS ${SETUP_PROJECT_PACKAGE_TARGETS}
-#     EXPORT "${targets_export_name}"
-#     LIBRARY DESTINATION "lib"
-#     ARCHIVE DESTINATION "lib"
-#     RUNTIME DESTINATION "bin"
-#     INCLUDES DESTINATION "${include_install_dir}"
-# )
-
-# # Headers:
-# #   * Source/foo/Bar.hpp -> <prefix>/include/foo/Bar.hpp
-# #   * Source/foo/Baz.hpp -> <prefix>/include/foo/Baz.hpp
-# install(
-#     DIRECTORY "Source/foo"
-#     DESTINATION "${include_install_dir}"
-#     FILES_MATCHING PATTERN "*.h*"
-# )
-
-# # Export headers:
-# #   * ${CMAKE_CURRENT_BINARY_DIR}/bar_export.h -> <prefix>/include/bar_export.h
-# #   * ${CMAKE_CURRENT_BINARY_DIR}/baz_export.h -> <prefix>/include/baz_export.h
-# install(
-#     FILES
-#         "${CMAKE_CURRENT_BINARY_DIR}/bar_export.h"
-#         "${CMAKE_CURRENT_BINARY_DIR}/baz_export.h"
-#     DESTINATION "${include_install_dir}"
-# )
 
 # Config
 #   * <prefix>/lib/cmake/Foo/FooConfig.cmake
 #   * <prefix>/lib/cmake/Foo/FooConfigVersion.cmake
 install(
-    FILES "${project_config}" "${version_config}"
-    DESTINATION "${config_install_dir}"
+    FILES "${PROJECT_CONFIG}" "${VERSION_CONFIG}"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
 )
 
 # Config
 #   * <prefix>/lib/cmake/Foo/FooTargets.cmake
 install(
-    EXPORT "${targets_export_name}"
+    EXPORT "${TARGETS_EXPORT_NAME}"
     NAMESPACE "${namespace}"
-    DESTINATION "${config_install_dir}"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
 )
 ENDMACRO(_SETUP_PROJECT_PACKAGE_FINALIZE)
 

--- a/base.cmake
+++ b/base.cmake
@@ -56,6 +56,7 @@ INCLUDE(cmake/uninstall.cmake)
 INCLUDE(cmake/install-data.cmake)
 INCLUDE(cmake/release.cmake)
 INCLUDE(cmake/version.cmake)
+INCLUDE(cmake/package.cmake)
 
  # --------- #
  # Constants #
@@ -210,77 +211,6 @@ MACRO(SETUP_PROJECT)
   _SETUP_PROJECT_DOCUMENTATION()
   _SETUP_PROJECT_PACKAGE_INIT()
 ENDMACRO(SETUP_PROJECT)
-
-# SETUP_PROJECT_PACKAGE_FINALIZE
-# -------------
-#
-# Generates PackageConfig.cmake files so users can call find_package(MyPackage)
-#
-# Initialize the PackageConfig installation configuration.
-# https://github.com/forexample/package-example
-#
-# This function does not take any argument but check that some
-# variables are defined (see documentation at the beginning of this
-# file).
-#
-# assumes SETUP_PROJECT() was called
-# internally the real requirement is that _SETUP_PROJECT_PACKAGE_INIT() was called
-MACRO(SETUP_PROJECT_PACKAGE_FINALIZE)
-
-####
-# Installation (https://github.com/forexample/package-example)
-
-# Layout. This works for all platforms:
-#   * <prefix>/lib/cmake/<PROJECT-NAME>
-#   * <prefix>/lib/
-#   * <prefix>/include/
-set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
-set(INCLUDE_INSTALL_DIR "include")
-set(INCLUDE_INSTALL_DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
-
-set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
-
-# Configuration
-set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
-set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
-set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(namespace "${PROJECT_NAME}::")
-
-# Include module with fuction 'write_basic_package_version_file'
-include(CMakePackageConfigHelpers)
-
-# Configure '<PROJECT-NAME>ConfigVersion.cmake'
-# Note: PROJECT_VERSION is used as a VERSION
-write_basic_package_version_file(
-    "${VERSION_CONFIG}" COMPATIBILITY SameMajorVersion
-)
-
-# Configure '<PROJECT-NAME>Config.cmake'
-# Use variables:
-#   * TARGETS_EXPORT_NAME
-#   * PROJECT_NAME
-configure_package_config_file(
-    "cmake/Config.cmake.in"
-    "${PROJECT_CONFIG}"
-    INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
-)
-
-# Config
-#   * <prefix>/lib/cmake/Foo/FooConfig.cmake
-#   * <prefix>/lib/cmake/Foo/FooConfigVersion.cmake
-install(
-    FILES "${PROJECT_CONFIG}" "${VERSION_CONFIG}"
-    DESTINATION "${CONFIG_INSTALL_DIR}"
-)
-
-# Config
-#   * <prefix>/lib/cmake/Foo/FooTargets.cmake
-install(
-    EXPORT "${TARGETS_EXPORT_NAME}"
-    NAMESPACE "${namespace}"
-    DESTINATION "${CONFIG_INSTALL_DIR}"
-)
-ENDMACRO(SETUP_PROJECT_PACKAGE_FINALIZE)
 
 
 # SETUP_PROJECT_FINALIZE

--- a/base.cmake
+++ b/base.cmake
@@ -103,6 +103,37 @@ MACRO(_CONCATENATE_ARGUMENTS OUTPUT SEPARATOR)
   MESSAGE(${${OUTPUT}})
 ENDMACRO(_CONCATENATE_ARGUMENTS OUTPUT)
 
+# _SETUP_PROJECT_PACKAGE_INIT
+# -------------
+#
+# Initialize the PackageConfig installation configuration.
+# https://github.com/forexample/package-example
+#
+# This function does not take any argument but check that some
+# variables are defined (see documentation at the beginning of this
+# file).
+#
+MACRO(_SETUP_PROJECT_PACKAGE_INIT)
+####
+# Installation (https://github.com/forexample/package-example)
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+set(include_install_destination "${include_install_dir}/${PROJECT_NAME}")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+ENDMACRO(_SETUP_PROJECT_PACKAGE_INIT)
+
 
 # SETUP_PROJECT
 # -------------
@@ -177,7 +208,111 @@ MACRO(SETUP_PROJECT)
   _SETUP_PROJECT_UNINSTALL()
   _SETUP_PROJECT_PKG_CONFIG()
   _SETUP_PROJECT_DOCUMENTATION()
+  _SETUP_PROJECT_PACKAGE_INIT()
 ENDMACRO(SETUP_PROJECT)
+
+# _SETUP_PROJECT_PACKAGE_FINALIZE
+# -------------
+#
+# Initialize the PackageConfig installation configuration.
+# https://github.com/forexample/package-example
+#
+# This function does not take any argument but check that some
+# variables are defined (see documentation at the beginning of this
+# file).
+#
+# assumes SETUP_PROJECT() was called
+# internally the real requirement is that _SETUP_PROJECT_PACKAGE_INIT() was called
+MACRO(_SETUP_PROJECT_PACKAGE_FINALIZE)
+
+####
+# Installation (https://github.com/forexample/package-example)
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+set(include_install_destination "${include_install_dir}/${PROJECT_NAME}")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Note: PROJECT_VERSION is used as a VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * targets_export_name
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# # Targets:
+# #   * <prefix>/lib/libbar.a
+# #   * <prefix>/lib/libbaz.a
+# #   * header location after install: <prefix>/include/foo/Bar.hpp
+# #   * headers can be included by C++ code `#include <foo/Bar.hpp>`
+# install(
+#     TARGETS ${SETUP_PROJECT_PACKAGE_TARGETS}
+#     EXPORT "${targets_export_name}"
+#     LIBRARY DESTINATION "lib"
+#     ARCHIVE DESTINATION "lib"
+#     RUNTIME DESTINATION "bin"
+#     INCLUDES DESTINATION "${include_install_dir}"
+# )
+
+# # Headers:
+# #   * Source/foo/Bar.hpp -> <prefix>/include/foo/Bar.hpp
+# #   * Source/foo/Baz.hpp -> <prefix>/include/foo/Baz.hpp
+# install(
+#     DIRECTORY "Source/foo"
+#     DESTINATION "${include_install_dir}"
+#     FILES_MATCHING PATTERN "*.h*"
+# )
+
+# # Export headers:
+# #   * ${CMAKE_CURRENT_BINARY_DIR}/bar_export.h -> <prefix>/include/bar_export.h
+# #   * ${CMAKE_CURRENT_BINARY_DIR}/baz_export.h -> <prefix>/include/baz_export.h
+# install(
+#     FILES
+#         "${CMAKE_CURRENT_BINARY_DIR}/bar_export.h"
+#         "${CMAKE_CURRENT_BINARY_DIR}/baz_export.h"
+#     DESTINATION "${include_install_dir}"
+# )
+
+# Config
+#   * <prefix>/lib/cmake/Foo/FooConfig.cmake
+#   * <prefix>/lib/cmake/Foo/FooConfigVersion.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/Foo/FooTargets.cmake
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+ENDMACRO(_SETUP_PROJECT_PACKAGE_FINALIZE)
+
 
 # SETUP_PROJECT_FINALIZE
 # ----------------------
@@ -189,6 +324,7 @@ MACRO(SETUP_PROJECT_FINALIZE)
   _SETUP_PROJECT_PKG_CONFIG_FINALIZE()
   _SETUP_PROJECT_DOCUMENTATION_FINALIZE()
   _SETUP_PROJECT_HEADER_FINAlIZE()
+  _SETUP_PROJECT_PACKAGE_FINALIZE()
   _SETUP_DEBIAN()
   # Install data if needed
   _INSTALL_PROJECT_DATA()

--- a/base.cmake
+++ b/base.cmake
@@ -211,8 +211,10 @@ MACRO(SETUP_PROJECT)
   _SETUP_PROJECT_PACKAGE_INIT()
 ENDMACRO(SETUP_PROJECT)
 
-# _SETUP_PROJECT_PACKAGE_FINALIZE
+# SETUP_PROJECT_PACKAGE_FINALIZE
 # -------------
+#
+# Generates PackageConfig.cmake files so users can call find_package(MyPackage)
 #
 # Initialize the PackageConfig installation configuration.
 # https://github.com/forexample/package-example
@@ -223,7 +225,7 @@ ENDMACRO(SETUP_PROJECT)
 #
 # assumes SETUP_PROJECT() was called
 # internally the real requirement is that _SETUP_PROJECT_PACKAGE_INIT() was called
-MACRO(_SETUP_PROJECT_PACKAGE_FINALIZE)
+MACRO(SETUP_PROJECT_PACKAGE_FINALIZE)
 
 ####
 # Installation (https://github.com/forexample/package-example)
@@ -278,7 +280,7 @@ install(
     NAMESPACE "${namespace}"
     DESTINATION "${CONFIG_INSTALL_DIR}"
 )
-ENDMACRO(_SETUP_PROJECT_PACKAGE_FINALIZE)
+ENDMACRO(SETUP_PROJECT_PACKAGE_FINALIZE)
 
 
 # SETUP_PROJECT_FINALIZE
@@ -291,7 +293,6 @@ MACRO(SETUP_PROJECT_FINALIZE)
   _SETUP_PROJECT_PKG_CONFIG_FINALIZE()
   _SETUP_PROJECT_DOCUMENTATION_FINALIZE()
   _SETUP_PROJECT_HEADER_FINAlIZE()
-  _SETUP_PROJECT_PACKAGE_FINALIZE()
   _SETUP_DEBIAN()
   # Install data if needed
   _INSTALL_PROJECT_DATA()

--- a/base.cmake
+++ b/base.cmake
@@ -56,7 +56,7 @@ INCLUDE(cmake/uninstall.cmake)
 INCLUDE(cmake/install-data.cmake)
 INCLUDE(cmake/release.cmake)
 INCLUDE(cmake/version.cmake)
-INCLUDE(cmake/package.cmake)
+INCLUDE(cmake/package-config.cmake)
 
  # --------- #
  # Constants #
@@ -103,38 +103,6 @@ MACRO(_CONCATENATE_ARGUMENTS OUTPUT SEPARATOR)
   ENDFOREACH(I RANGE 2 ${ARGC})
   MESSAGE(${${OUTPUT}})
 ENDMACRO(_CONCATENATE_ARGUMENTS OUTPUT)
-
-# _SETUP_PROJECT_PACKAGE_INIT
-# -------------
-#
-# Initialize the PackageConfig installation configuration.
-# https://github.com/forexample/package-example
-#
-# This function does not take any argument but check that some
-# variables are defined (see documentation at the beginning of this
-# file).
-#
-MACRO(_SETUP_PROJECT_PACKAGE_INIT)
-####
-# Installation (https://github.com/forexample/package-example)
-
-# Layout. This works for all platforms:
-#   * <prefix>/lib/cmake/<PROJECT-NAME>
-#   * <prefix>/lib/
-#   * <prefix>/include/
-set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
-set(INCLUDE_INSTALL_DIR "include")
-set(INCLUDE_INSTALL_DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
-
-set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
-
-# Configuration
-set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
-set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
-set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(namespace "${PROJECT_NAME}::")
-ENDMACRO(_SETUP_PROJECT_PACKAGE_INIT)
-
 
 # SETUP_PROJECT
 # -------------

--- a/package-config.cmake
+++ b/package-config.cmake
@@ -15,6 +15,39 @@
 
 
 
+
+# _SETUP_PROJECT_PACKAGE_INIT
+# -------------
+#
+# Initialize the PackageConfig installation configuration.
+# https://github.com/forexample/package-example
+#
+# This function does not take any argument but check that some
+# variables are defined (see documentation at the beginning of this
+# file).
+#
+MACRO(_SETUP_PROJECT_PACKAGE_INIT)
+####
+# Installation (https://github.com/forexample/package-example)
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(INCLUDE_INSTALL_DIR "include")
+set(INCLUDE_INSTALL_DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
+
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+ENDMACRO(_SETUP_PROJECT_PACKAGE_INIT)
+
+
 # SETUP_PROJECT_PACKAGE_FINALIZE
 # -------------
 #

--- a/package.cmake
+++ b/package.cmake
@@ -1,0 +1,90 @@
+# Copyright (C) 2016  LAAS-CNRS, JRL AIST-CNRS and others.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+# SETUP_PROJECT_PACKAGE_FINALIZE
+# -------------
+#
+# Generates CMake PackageConfig.cmake, Targets, and Version 
+# files so users can call:
+#
+# find_package(MyPackage)
+#
+# Initialize the PackageConfig installation configuration.
+# https://github.com/forexample/package-example
+#
+# This function does not take any argument but check that some
+# variables are defined (see documentation at the beginning of this
+# file).
+#
+# assumes SETUP_PROJECT() was called
+# internally the real requirement is that _SETUP_PROJECT_PACKAGE_INIT() was called
+MACRO(SETUP_PROJECT_PACKAGE_FINALIZE)
+
+####
+# Installation (https://github.com/forexample/package-example)
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(INCLUDE_INSTALL_DIR "include")
+set(INCLUDE_INSTALL_DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
+
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Note: PROJECT_VERSION is used as a VERSION
+write_basic_package_version_file(
+    "${VERSION_CONFIG}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${PROJECT_CONFIG}"
+    INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/Foo/FooConfig.cmake
+#   * <prefix>/lib/cmake/Foo/FooConfigVersion.cmake
+install(
+    FILES "${PROJECT_CONFIG}" "${VERSION_CONFIG}"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/Foo/FooTargets.cmake
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+ENDMACRO(SETUP_PROJECT_PACKAGE_FINALIZE)


### PR DESCRIPTION
based on: https://github.com/forexample/package-example

This helps generate config files so other regular cmake packages can find and use library dependencies. For example a simple change to [RBDyn/src/CMakeLists.txt](https://github.com/jrl-umi3218/RBDyn/blob/master/src/CMakeLists.txt) will install the following:

```
-- /usr/local/lib/cmake/RBDyn/RBDynConfig.cmake
-- /usr/local/lib/cmake/RBDyn/RBDynConfigVersion.cmake
-- /usr/local/lib/cmake/RBDyn/RBDynTargets.cmake
-- /usr/local/lib/cmake/RBDyn/RBDynTargets-noconfig.cmake
```

That way a call to find_package(RBDyn) will automatically be configured!

Here is an example change to [RBDyn/src/CMakeLists.txt](https://github.com/jrl-umi3218/RBDyn/blob/master/src/CMakeLists.txt), which I will submit separately once this is merged:

``` cmake
set(SOURCES MultiBodyGraph.cpp MultiBody.cpp MultiBodyConfig.cpp
  FK.cpp FV.cpp FA.cpp Jacobian.cpp ID.cpp IK.cpp IS.cpp FD.cpp EulerIntegration.cpp
  CoM.cpp Momentum.cpp ZMP.cpp IDIM.cpp VisServo.cpp)
set(HEADERS Body.h Joint.h MultiBodyGraph.h MultiBody.h MultiBodyConfig.h
  FK.h FV.h FA.h Jacobian.h ID.h IK.h IS.h FD.h EulerIntegration.h CoM.h
  Momentum.h ZMP.h IDIM.h VisServo.h)

add_library(RBDyn SHARED ${SOURCES} ${HEADERS})
PKG_CONFIG_USE_DEPENDENCY(RBDyn SpaceVecAlg)
set_target_properties(RBDyn PROPERTIES COMPILE_FLAGS "-Drbdyn_EXPORTS")
set_target_properties(RBDyn PROPERTIES SOVERSION 0 VERSION 0.9.0)


# Targets:
#   * <prefix>/lib/libbar.a
#   * <prefix>/lib/libbaz.a
#   * header location after install: <prefix>/include/foo/Bar.hpp
#   * headers can be included by C++ code `#include <foo/Bar.hpp>`
install(
    TARGETS RBDyn
    EXPORT "${targets_export_name}"
    LIBRARY DESTINATION "lib"
    ARCHIVE DESTINATION "lib"
    RUNTIME DESTINATION "bin"
    INCLUDES DESTINATION "${include_install_dir}"
)
install(FILES ${HEADERS} DESTINATION ${include_install_destination})
```
