### PR TITLE
[Boost] Use AUTHOR_WARNING for boost Python linkage macro

### DIFF
--- a/boost.cmake
+++ b/boost.cmake
@@ -87,9 +87,8 @@ MACRO(SEARCH_FOR_BOOST)
   # We then remove boost_python from the global Boost_LIBRARIES list to handle it with specific care.
   IF(Boost_PYTHON_LIBRARY)
     LIST(REMOVE_ITEM Boost_LIBRARIES ${Boost_PYTHON_LIBRARY})
-    MESSAGE(WARNING 
-            "The boost_python library have been removed from the Boost_LIBRARIES variable.
-            \n To link againt boost_python, please use the macro TARGET_LINK_BOOST_PYTHON."
+    MESSAGE(AUTHOR_WARNING
+            "The boost_python library has been removed from the Boost_LIBRARIES variable. To link againt boost_python, please use the macro TARGET_LINK_BOOST_PYTHON."
            )
   ENDIF(Boost_PYTHON_LIBRARY)
 


### PR DESCRIPTION
This PR prevents the warning message to be displayed for normal users.