### PR TITLE
 Check cmake version before casting list to string

### DIFF
--- a/pkg-config.cmake
+++ b/pkg-config.cmake
@@ -670,8 +670,13 @@ MACRO(PKG_CONFIG_USE_LCOMPILE_DEPENDENCY TARGET PREFIX)
       LIST(APPEND CFLAGS "${FLAG}")
     ENDFOREACH()
   ENDIF()
-  # This cast from LIST to STRING is mandatory for old CMake versions
-  STRING(REPLACE ";" " " CFLAGS "${CFLAGS}")
+
+  IF(${CMAKE_VERSION} VERSION_LESS 2.8.12)
+    # This cast from LIST to STRING is mandatory for old CMake versions,
+    # but harmful for CMake 2.8.12, and useless for 3.2.2 and above
+    STRING(REPLACE ";" " " CFLAGS "${CFLAGS}")
+  ENDIF(${CMAKE_VERSION} VERSION_LESS 2.8.12)
+
   SET_TARGET_PROPERTIES(${TARGET} PROPERTIES ${COMPILE_OPTIONS_NAME} "${CFLAGS}")
 
   # Include/libraries paths seems to be filtered on Linux, add paths


### PR DESCRIPTION
 This avoids quoting cflags while building, see #106 