### PR TITLE
Create a dependency between template CSS creation and doc target

### DIFF
--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -87,6 +87,13 @@ MACRO(_SETUP_PROJECT_DOCUMENTATION)
         WORKING_DIRECTORY doc
         COMMENT "Generating Doxygen template files"
         )
+      ADD_CUSTOM_TARGET(generate-template-css
+        DEPENDS
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/header.html
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/footer.html
+        ${CMAKE_CURRENT_BINARY_DIR}/doc/doxygen.css
+        )
+      ADD_DEPENDENCIES(doc generate-template-css)
     ELSE (DOXYGEN_USE_TEMPLATE_CSS)
       FILE (COPY
         ${PROJECT_SOURCE_DIR}/cmake/doxygen/doxygen.css


### PR DESCRIPTION
This PR is a follow-up to #72 

This makes doc dependent on the generation of doxygen template CSS. Otherwise, the custom command is not run and the generated documentation does not have its stylesheet.