### PR TITLE
[Boost] Remove useless warning message

### DIFF
--- a/boost.cmake
+++ b/boost.cmake
@@ -153,9 +153,6 @@ MACRO(SEARCH_FOR_BOOST)
   # We then remove boost_python from the global Boost_LIBRARIES list to handle it with specific care.
   IF(Boost_PYTHON_LIBRARY)
     LIST(REMOVE_ITEM Boost_LIBRARIES ${Boost_PYTHON_LIBRARY})
-    MESSAGE(AUTHOR_WARNING
-            "The boost_python library has been removed from the Boost_LIBRARIES variable. To link againt boost_python, please use the macro TARGET_LINK_BOOST_PYTHON."
-           )
   ENDIF(Boost_PYTHON_LIBRARY)
 
 ENDMACRO(SEARCH_FOR_BOOST)


### PR DESCRIPTION
The warning was here to highlight the modification.
It seems now no more useful, and can lead to some confusions to common people who are not developers.