### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+hpp/idl/*.pyc


### PR DESCRIPTION
1d9aeca25e970d2d967fd5be0fb93fe961db121b introduced a Python script. When the Python script is used, the file is compiled and the pyc file makes the module dirty. This pollutes git status.

I didn't want to copy the file to the build directory because it seems overkill but I can do it if necessary.