### PR TITLE
fix formatting errors

### DIFF
--- a/pkg-config.cmake
+++ b/pkg-config.cmake
@@ -907,8 +907,10 @@ ENDMACRO(BUILD_PREFIX_FOR_PKG)
 #                         this option changes this behaviour
 #
 
-MACRO(PKG_CONFIG_USE_DEPENDENCY TARGET DEPENDENCY) SET(options
-  NO_INCLUDE_SYSTEM) SET(oneValueArgs ) SET(multiValueArgs )
+MACRO(PKG_CONFIG_USE_DEPENDENCY TARGET DEPENDENCY)
+  SET(options NO_INCLUDE_SYSTEM)
+  SET(oneValueArgs )
+  SET(multiValueArgs )
   cmake_parse_arguments(PKG_CONFIG_USE_DEPENDENCY "${options}"
     "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   BUILD_PREFIX_FOR_PKG(${DEPENDENCY} PREFIX)


### PR DESCRIPTION
Hi,

I had the following error:
```
CMake Error: Error in cmake code at cmake/pkg-config.cmake:910:
Parse error.  Expected a newline, got identifier with text "SET".
CMake Error at cmake/base.cmake:98 (INCLUDE):
  include could not find load file:

    cmake/pkg-config.cmake
Call Stack (most recent call first):
  CMakeLists.txt:3 (INCLUDE)
```