### PR TITLE
Fix non-backward compatible change.

### DIFF
--- a/base.cmake
+++ b/base.cmake
@@ -94,7 +94,6 @@ INCLUDE(cmake/release.cmake)
 INCLUDE(cmake/version.cmake)
 INCLUDE(cmake/package-config.cmake)
 INCLUDE(cmake/version-script.cmake)
-INCLUDE(cmake/test.cmake)
 
  # --------- #
  # Constants #


### PR DESCRIPTION
The current change creates the following error on some projects:
```
CMake Error at /usr/share/cmake-3.5/Modules/CTestTargets.cmake:20 (message):
  Do not include(CTest) before calling project().
Call Stack (most recent call first):
  /usr/share/cmake-3.5/Modules/CTest.cmake:281 (include)
  cmake/test.cmake:16 (include)
  cmake/base.cmake:97 (INCLUDE)
  CMakeLists.txt:23 (include)
```

This was introduced in https://github.com/jrl-umi3218/jrl-cmakemodules/pull/222. I don't know whether it is necessary.