### PR TITLE
PkgConfig: do not advise putting spaces around operators

### DIFF
--- a/pkg-config.cmake
+++ b/pkg-config.cmake
@@ -256,7 +256,7 @@ ENDMACRO()
 #
 # PKG_CONFIG_STRING	: string passed to pkg-config to check the version.
 #			  Typically, this string looks like:
-#                         ``my-package >= 0.5''
+#                         ``my-package>=0.5''
 #
 MACRO(ADD_DEPENDENCY P_REQUIRED COMPILE_TIME_ONLY PKG_CONFIG_STRING PKG_CONFIG_DEBUG_STRING)
   _PARSE_PKG_CONFIG_STRING ("${PKG_CONFIG_STRING}" LIBRARY_NAME PREFIX)
@@ -495,12 +495,12 @@ ENDMACRO(_GET_PKG_CONFIG_DEBUG_STRING)
 #     be found.
 #
 #     :PKG_CONFIG_STRING: string passed to pkg-config to check the version.
-#       Typically, this string looks like: ``my-package >= 0.5``
+#       Typically, this string looks like: ``my-package>=0.5``
 #
 #     :PKG_CONFIG_DEBUG_STRING: (optional) string passed to pkg-config to
 #       check the version. The package found this way will be used in place
 #       of the first provided if the build is happening in DEBUG mode.
-#       This string might look like: ``my-package_d >= 0.5``
+#       This string might look like: ``my-package_d>=0.5``
 #
 #     An optional argument can be passed to define an alternate PKG_CONFIG_STRING
 #     for debug builds. It should follow the same rule as PKG_CONFIG_STRING.
@@ -519,12 +519,12 @@ ENDMACRO(ADD_REQUIRED_DEPENDENCY)
 #     be found.
 #
 #     :PKG_CONFIG_STRING: string passed to pkg-config to check the version.
-#       Typically, this string looks like: ``my-package >= 0.5``
+#       Typically, this string looks like: ``my-package>=0.5``
 #
 #     :PKG_CONFIG_DEBUG_STRING: (optional) string passed to pkg-config to
 #       check the version. The package found this way will be used in place
 #       of the first provided if the build is happening in DEBUG mode.
-#       This string might look like: ``my-package_d >= 0.5``
+#       This string might look like: ``my-package_d>=0.5``
 #
 #     An optional argument can be passed to define an alternate PKG_CONFIG_STRING
 #     for debug builds. It should follow the same rule as PKG_CONFIG_STRING.
@@ -544,12 +544,12 @@ ENDMACRO(ADD_OPTIONAL_DEPENDENCY)
 #     of the PROJECT.
 #
 #     :PKG_CONFIG_STRING: string passed to pkg-config to check the version.
-#       Typically, this string looks like: ``my-package >= 0.5``
+#       Typically, this string looks like: ``my-package>=0.5``
 #
 #     :PKG_CONFIG_DEBUG_STRING: (optional) string passed to pkg-config to
 #       check the version. The package found this way will be used in place
 #       of the first provided if the build is happening in DEBUG mode.  This
-#       string might look like: ``my-package_d >= 0.5``
+#       string might look like: ``my-package_d>=0.5``
 #
 #
 MACRO(ADD_COMPILE_DEPENDENCY PKG_CONFIG_STRING)


### PR DESCRIPTION
...in accordance with cmake's documentation.

freedesktop [1] and perl [2] implementations of pkg-config differ
in the way they parse extra spaces in version constraints
(like eigen3 >= 3.0.5). See the following table for examples showing
 how library names are parsed by the two implementations:

| input             | freedesktop     | perl            |
|-------------------|-----------------|-----------------|
|                   | 0.29.1          | 0.23026         |
| "eigen3 >= 3.0.5" | "eigen3"        | "eigen3"        |
| "eigen3>=3.0.5"   | "eigen3>=3.0.5" | "eigen3>=3.0.5" |
| "eigen3 >= 3.0.5" | "eigen3"        | "eigen3 "       |

cmake's FindPkgConfig.cmake documentation [3] advises
using pkg_check_modules without spaces around the operator.
Hence, one should do:

  pkg_check_modules(EIGEN3 eigen3>=3.0.5)

The cmake function then adds spaces around the operator
before calling pkg-config (see implementation at [4]).

So if the end-user writes

  pkg_check_modules(EIGEN3 eigen3 >= 3.0.5)

pkg-config will see "eigen3  >=  3.0.5" and perl's implementation
will look for a lib named "eigen3 " and fail.

[1] http://pkg-config.freedesktop.org
[2] https://metacpan.org/pod/PkgConfig
[3] https://cmake.org/cmake/help/v3.15/module/FindPkgConfig.html
[4] https://github.com/Kitware/CMake/blob/v3.15.5/Modules/FindPkgConfig.cmake#L432