### PR TITLE
Create reinstall target

### DIFF
--- a/cmake_reinstall.cmake.in
+++ b/cmake_reinstall.cmake.in
@@ -1,0 +1,19 @@
+# Copyright (C) 2019 LAAS-CNRS, JRL AIST-CNRS, INRIA.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+cmake_policy(SET CMP0007 NEW)
+if(EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  execute_process(COMMAND "@CMAKE_COMMAND@" --build "@PROJECT_BINARY_DIR@" --target uninstall --config $<CONFIGURATION>)
+endif()
+execute_process(COMMAND "@CMAKE_COMMAND@" --build "@PROJECT_BINARY_DIR@" --target install --config $<CONFIGURATION>)

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -76,3 +76,9 @@ FOREACH(file ${files})
       )
   ENDIF(EXISTS "$ENV{DESTDIR}${file}")
 ENDFOREACH(file)
+EXECUTE_PROCESS(
+  COMMAND "@CMAKE_COMMAND@" -E remove "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt"
+  RESULT_VARIABLE rm_resval
+  OUTPUT_VARIABLE rm_out
+  ERROR_QUIET
+  )

--- a/uninstall.cmake
+++ b/uninstall.cmake
@@ -33,4 +33,18 @@ MACRO(_SETUP_PROJECT_UNINSTALL)
     "${CMAKE_COMMAND}" -P
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
     )
+
+  CONFIGURE_FILE(
+    "${PROJECT_SOURCE_DIR}/cmake/cmake_reinstall.cmake.in"
+    "${PROJECT_BINARY_DIR}/cmake/cmake_reinstall.cmake.configured"
+    )
+  FILE(GENERATE
+    OUTPUT "${PROJECT_BINARY_DIR}/cmake/$<CONFIGURATION>/cmake_reinstall.cmake"
+    INPUT "${PROJECT_BINARY_DIR}/cmake/cmake_reinstall.cmake.configured"
+    )
+  ADD_CUSTOM_TARGET(
+    reinstall
+    "${CMAKE_COMMAND}" -P
+    "${PROJECT_BINARY_DIR}/cmake/$<CONFIGURATION>/cmake_reinstall.cmake"
+    )
 ENDMACRO(_SETUP_PROJECT_UNINSTALL)


### PR DESCRIPTION
Closes #298

This is implemented so that `make reinstall` is also working on the first time it's invoked or if the project has already been uninstalled.

For this to work correctly, `make uninstall` also removes the install manifest