### PR TITLE
Fix isssue #398

### DIFF
--- a/package-config.cmake
+++ b/package-config.cmake
@@ -168,9 +168,12 @@ install(
 
 # Config
 #   * <prefix>/lib/cmake/Foo/FooTargets.cmake
-install(
+if(${TARGETS_EXPORT_NAME})
+  install(
     EXPORT "${TARGETS_EXPORT_NAME}"
     NAMESPACE "${namespace}"
     DESTINATION "${CONFIG_INSTALL_DIR}"
-)
+    )
+endif(${TARGETS_EXPORT_NAME})
+
 ENDMACRO(SETUP_PROJECT_PACKAGE_FINALIZE)


### PR DESCRIPTION
Do not call INSTALL(EXPORT ...) when having no targets but generates the Config.cmake file.