### PR TITLE
[Python] Allow user to provide PYTHON_SITELIB

### DIFF
--- a/python.cmake
+++ b/python.cmake
@@ -80,7 +80,7 @@ MACRO(FINDPYTHON)
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_STRIP_TRAILING_WHITESPACE
         )
-      
+
       STRING(REGEX REPLACE "Python " "" _PYTHON_VERSION ${_PYTHON_VERSION_OUTPUT})
       STRING(REGEX REPLACE "\\." ";" _PYTHON_VERSION ${_PYTHON_VERSION})
       LIST(GET _PYTHON_VERSION 0 _PYTHON_VERSION_MAJOR)
@@ -104,7 +104,7 @@ MACRO(FINDPYTHON)
         SET(_PYTHON_VERSION_MAJOR 2)
       ENDIF(NOT Python2_FOUND)
     ENDIF(PYTHON_EXECUTABLE)
-    
+
     SET(_PYTHON_PREFIX "Python${_PYTHON_VERSION_MAJOR}")
 
     IF(${_PYTHON_PREFIX}_FOUND)
@@ -175,33 +175,35 @@ MACRO(FINDPYTHON)
   MESSAGE(STATUS "PythonLibraryDirs: ${PYTHON_LIBRARY_DIRS}")
   MESSAGE(STATUS "PythonLibVersionString: ${PYTHONLIBS_VERSION_STRING}")
 
-  # Use either site-packages (default) or dist-packages (Debian packages) directory
-  OPTION(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
-  # ref. https://docs.python.org/3/library/site.html
-  OPTION(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" OFF)
+  IF(NOT PYTHON_SITELIB)
+    # Use either site-packages (default) or dist-packages (Debian packages) directory
+    OPTION(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
+    # ref. https://docs.python.org/3/library/site.html
+    OPTION(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" OFF)
 
-  IF(PYTHON_STANDARD_LAYOUT)
-    SET(PYTHON_SITELIB_CMD "import sys, os; print(os.sep.join(['lib', 'python' + sys.version[:3], 'site-packages']))")
-  ELSE(PYTHON_STANDARD_LAYOUT)
-    SET(PYTHON_SITELIB_CMD "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix='', plat_specific=False))")
-  ENDIF(PYTHON_STANDARD_LAYOUT)
+    IF(PYTHON_STANDARD_LAYOUT)
+      SET(PYTHON_SITELIB_CMD "import sys, os; print(os.sep.join(['lib', 'python' + sys.version[:3], 'site-packages']))")
+    ELSE(PYTHON_STANDARD_LAYOUT)
+      SET(PYTHON_SITELIB_CMD "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix='', plat_specific=False))")
+    ENDIF(PYTHON_STANDARD_LAYOUT)
 
-  EXECUTE_PROCESS(
-    COMMAND "${PYTHON_EXECUTABLE}" "-c"
-    "${PYTHON_SITELIB_CMD}"
-    OUTPUT_VARIABLE PYTHON_SITELIB
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET)
+    EXECUTE_PROCESS(
+      COMMAND "${PYTHON_EXECUTABLE}" "-c"
+      "${PYTHON_SITELIB_CMD}"
+      OUTPUT_VARIABLE PYTHON_SITELIB
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET)
 
-  # Keep compatility with former jrl-cmake-modules versions
-  IF(PYTHON_DEB_LAYOUT)
-    STRING(REPLACE "site-packages" "dist-packages" PYTHON_SITELIB "${PYTHON_SITELIB}")
-  ENDIF(PYTHON_DEB_LAYOUT)
+    # Keep compatility with former jrl-cmake-modules versions
+    IF(PYTHON_DEB_LAYOUT)
+      STRING(REPLACE "site-packages" "dist-packages" PYTHON_SITELIB "${PYTHON_SITELIB}")
+    ENDIF(PYTHON_DEB_LAYOUT)
 
-  # If PYTHON_PACKAGES_DIR is defined, then force the Python packages directory name
-  IF(PYTHON_PACKAGES_DIR)
-    STRING(REGEX REPLACE "(site-packages|dist-packages)" "${PYTHON_PACKAGES_DIR}" PYTHON_SITELIB "${PYTHON_SITELIB}")
-  ENDIF(PYTHON_PACKAGES_DIR)
+    # If PYTHON_PACKAGES_DIR is defined, then force the Python packages directory name
+    IF(PYTHON_PACKAGES_DIR)
+      STRING(REGEX REPLACE "(site-packages|dist-packages)" "${PYTHON_PACKAGES_DIR}" PYTHON_SITELIB "${PYTHON_SITELIB}")
+    ENDIF(PYTHON_PACKAGES_DIR)
+  ENDIF(NOT PYTHON_SITELIB)
 
   MESSAGE(STATUS "Python site lib: ${PYTHON_SITELIB}")
 
@@ -252,11 +254,11 @@ ENDMACRO(FINDPYTHON)
 # .. command:: DYNAMIC_GRAPH_PYTHON_MODULE ( SUBMODULENAME LIBRARYNAME TARGETNAME INSTALL_INIT_PY=1 SOURCE_PYTHON_MODULE=cmake/dynamic_graph/python-module-py.cc)
 #
 #   Add a python submodule to dynamic_graph
-#  
+#
 #   :param SUBMODULENAME: the name of the submodule (can be foo/bar),
-#  
+#
 #   :param LIBRARYNAME:   library to link the submodule with.
-#  
+#
 #   :param TARGETNAME:     name of the target: should be different for several
 #                   calls to the macro.
 #
@@ -265,7 +267,7 @@ ENDMACRO(FINDPYTHON)
 #
 #   :param SOURCE_PYTHON_MODULE: Location of the cpp file for the python module in the package.
 #                   Set to cmake/dynamic_graph/python-module-py.cc by default.
-# 
+#
 #  .. note::
 #    Before calling this macro, set variable NEW_ENTITY_CLASS as
 #    the list of new Entity types that you want to be bound.
@@ -277,7 +279,7 @@ MACRO(DYNAMIC_GRAPH_PYTHON_MODULE SUBMODULENAME LIBRARYNAME TARGETNAME)
   # By default the __init__.py file is installed.
   SET(INSTALL_INIT_PY 1)
   SET(SOURCE_PYTHON_MODULE "cmake/dynamic_graph/python-module-py.cc")
-    
+
   # Check if there is optional parameters.
   set(extra_macro_args ${ARGN})
   list(LENGTH extra_macro_args num_extra_args)
@@ -287,7 +289,7 @@ MACRO(DYNAMIC_GRAPH_PYTHON_MODULE SUBMODULENAME LIBRARYNAME TARGETNAME)
       list(GET extra_macro_args 1 SOURCE_PYTHON_MODULE)
     endif(${num_extra_args} GREATER 1)
   endif(${num_extra_args} GREATER 0)
-  
+
   IF(NOT DEFINED PYTHONLIBS_FOUND)
     FINDPYTHON()
   ELSEIF(NOT ${PYTHONLIBS_FOUND} STREQUAL "TRUE")
@@ -346,7 +348,7 @@ MACRO(DYNAMIC_GRAPH_PYTHON_MODULE SUBMODULENAME LIBRARYNAME TARGETNAME)
       FILES ${PROJECT_BINARY_DIR}/src/dynamic_graph/${SUBMODULENAME}/__init__.py
       DESTINATION ${PYTHON_INSTALL_DIR}
       )
-    
+
   ENDIF(${INSTALL_INIT_PY} EQUAL 1)
 
 ENDMACRO(DYNAMIC_GRAPH_PYTHON_MODULE SUBMODULENAME)


### PR DESCRIPTION
Hi,

This is just englobing the `PYTHON_SITELIB` computation in a guard, allowing the user to directly provide it. This was requested in https://github.com/Gepetto/example-robot-data/pull/38.

eg.
```bash
╰─>$ cmake -DCMAKE_INSTALL_PREFIX=/tmp/foo -DPYTHON_SITELIB=/tmp/bar ..
[…]
-- Found Python3: /usr/bin/python (found version "3.8.3") found components: Interpreter Development 
-- PythonLibraryDirs: /usr/lib
-- PythonLibVersionString: 3.8.3
-- Python site lib: /tmp/bar
```

(obviously, the site lib can also be inside the install prefix)