### PR TITLE
[find-external/cppad] Fix prefix hints

### DIFF
--- a/find-external/CppAD/Findcppad.cmake
+++ b/find-external/CppAD/Findcppad.cmake
@@ -16,10 +16,12 @@
 FIND_PATH(cppad_INCLUDE_DIR
   NAMES cppad/configure.hpp
   PATHS ${cppad_PREFIX}
+  PATH_SUFFIXES include
   )
 FIND_LIBRARY(cppad_LIBRARY
   NAMES cppad_lib
   PATHS ${cppad_PREFIX}
+  PATH_SUFFIXES lib
   )
 
 IF(cppad_INCLUDE_DIR AND EXISTS "${cppad_INCLUDE_DIR}/cppad/configure.hpp")

--- a/find-external/CppAD/Findcppadcg.cmake
+++ b/find-external/CppAD/Findcppadcg.cmake
@@ -14,6 +14,7 @@
 FIND_PATH(cppadcg_INCLUDE_DIR
   NAMES cppad/cg.hpp
   PATHS ${cppadcg_PREFIX}
+  PATH_SUFFIXES include
   )
 
 IF(cppadcg_INCLUDE_DIR AND EXISTS "${cppadcg_INCLUDE_DIR}/cppad/cg/configure.hpp")


### PR DESCRIPTION
As @nmansard found that `-Dcppadcg_PREFIX=…` didn't work as expected.