### PR TITLE
Use CMAKE_SOURCE_DIR instead of PROJECT_SOURCE_DIR

### DIFF
--- a/boost.cmake
+++ b/boost.cmake
@@ -32,7 +32,7 @@ FUNCTION(SEARCH_FOR_BOOST_COMPONENT boost_python_name found)
 ENDFUNCTION(SEARCH_FOR_BOOST_COMPONENT boost_python_name found)
 
 IF(CMAKE_VERSION VERSION_LESS "3.12")
-  SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/boost ${CMAKE_MODULE_PATH})
+  SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/boost ${CMAKE_MODULE_PATH})
   MESSAGE(STATUS "CMake versions older than 3.12 may warn when looking to Boost components. Custom macros are used to find it.")
 ENDIF(CMAKE_VERSION VERSION_LESS "3.12")
 


### PR DESCRIPTION
because CMAKE_SOURCE_DIR is always defined while PROJECT_SOURCE_DIR
is only defined after `project` has been called.