### PR TITLE
package-config: replace CMAKE_CURRENT_LIST_DIR by PROJECT_JRL_CMAKE_MODULE_DIR

### DIFF
--- a/package-config.cmake
+++ b/package-config.cmake
@@ -229,7 +229,7 @@ macro(PROJECT_INSTALL_COMPONENT COMPONENT)
   set(COMPONENT_EXTRA_MACRO "${PARSED_ARGN_EXTRA_MACRO}")
   include(CMakePackageConfigHelpers)
   configure_package_config_file(
-      "${CMAKE_CURRENT_LIST_DIR}/componentConfig.cmake.in"
+      "${PROJECT_JRL_CMAKE_MODULE_DIR}/componentConfig.cmake.in"
       "${COMPONENT_CONFIG}"
       INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
       NO_CHECK_REQUIRED_COMPONENTS_MACRO


### PR DESCRIPTION
Another fix after #449 : this one fix an issue about a `<project>/componentConfig.cmake.in` not found, while it is in `<project>/cmake/componentConfig.cmake.in`.