### PR TITLE
Use CMAKE_INSTALL_LIBDIR instead of lib for package config

### DIFF
--- a/package-config.cmake
+++ b/package-config.cmake
@@ -34,7 +34,7 @@ MACRO(_SETUP_PROJECT_PACKAGE_INIT)
 #   * <prefix>/lib/cmake/<PROJECT-NAME>
 #   * <prefix>/lib/
 #   * <prefix>/include/
-set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(INCLUDE_INSTALL_DIR "include")
 set(INCLUDE_INSTALL_DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
 
@@ -115,7 +115,7 @@ MACRO(SETUP_PROJECT_PACKAGE_FINALIZE)
 #   * <prefix>/lib/cmake/<PROJECT-NAME>
 #   * <prefix>/lib/
 #   * <prefix>/include/
-set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(INCLUDE_INSTALL_DIR "include")
 set(INCLUDE_INSTALL_DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
 


### PR DESCRIPTION
This PR uses the `CMAKE_INSTALL_LIBDIR` variable to install the CMake configuration files.

This should mostly affect packaging (ping @nim65s )