### PR TITLE
[test] Add custom target run_tests to run ctest

### DIFF
--- a/test.cmake
+++ b/test.cmake
@@ -46,7 +46,7 @@ IF(NOT TARGET build_tests)
 ENDIF()
 
 # Add new target 'run_tests' to improve integration with build tooling
-IF(NOT TARGET run_tests)
+IF(NOT CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT TARGET run_tests)
   ADD_CUSTOM_TARGET(run_tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -V
     VERBATIM

--- a/test.cmake
+++ b/test.cmake
@@ -45,6 +45,14 @@ IF(NOT TARGET build_tests)
   ADD_CUSTOM_TARGET(build_tests)
 ENDIF()
 
+# Add new target 'run_tests' to improve integration with build tooling
+IF(NOT TARGET run_tests)
+  ADD_CUSTOM_TARGET(run_tests
+    COMMAND ctest
+    VERBATIM
+  )
+ENDIF()
+
 IF(NOT DEFINED ctest_build_tests_exists)
   SET_PROPERTY(GLOBAL PROPERTY ctest_build_tests_exists OFF)
 ENDIF(NOT DEFINED ctest_build_tests_exists)

--- a/test.cmake
+++ b/test.cmake
@@ -48,7 +48,7 @@ ENDIF()
 # Add new target 'run_tests' to improve integration with build tooling
 IF(NOT TARGET run_tests)
   ADD_CUSTOM_TARGET(run_tests
-    COMMAND ctest --output-on-failure -V
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -V
     VERBATIM
   )
 ENDIF()

--- a/test.cmake
+++ b/test.cmake
@@ -48,7 +48,7 @@ ENDIF()
 # Add new target 'run_tests' to improve integration with build tooling
 IF(NOT TARGET run_tests)
   ADD_CUSTOM_TARGET(run_tests
-    COMMAND ctest
+    COMMAND ctest --output-on-failure -V
     VERBATIM
   )
 ENDIF()


### PR DESCRIPTION
This improves the integration with build tooling and CI systems including colcon and catkin_make_isolated. Without this target, the unit tests defined by the test macro cannot automatically be run with colcon/catkin_make_isolated tooling. Having this target enables us to activate full ROS-CI for CMake projects based on jrl-cmakemodules.(*)

(*) With a caveat of registration of projects from underlay workspaces that happens with some build tools such as colcon but not others such as catkin-tools that is yet to be resolved.