### PR TITLE
update minimum required to 3.1

### DIFF
--- a/_unittests/python/CMakeLists.txt
+++ b/_unittests/python/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Target-based approach should work from CMake 2.8.12 but it should fully work from 3.1
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 
 # These variables have to be defined before running SETUP_PROJECT
 set(PROJECT_NAME jrl-cmakemodules-python)

--- a/gtest/CMakeLists.txt.in
+++ b/gtest/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.1)
 
 project(gtest NONE)
 


### PR DESCRIPTION
fix warnings like:

> CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
>   Compatibility with CMake < 2.8.12 will be removed from a future version of
>   CMake.

also ref. #338