### PR TITLE
Fix for weird CMake versions

### DIFF
--- a/version-script.cmake
+++ b/version-script.cmake
@@ -15,7 +15,9 @@
 
 include(CheckCCompilerFlag)
 # Introduced in 3.18.0 but VERSION_GREAT_OR_EQUAL is not available in CMake 3.1
-if(${CMAKE_VERSION} VERSION_GREATER 3.17.6)
+if(${CMAKE_VERSION} VERSION_LESS 3.18.0)
+# Do nothing
+else()
   cmake_policy(PUSH)
   cmake_policy(SET CMP0057 NEW) # if IN_LIST
   include(CheckLinkerFlag)


### PR DESCRIPTION
In some systems (e.g. windows), the cmake version string looks like this `3.17.20032601-MSVC_2`. This causes the check `if(${CMAKE_VERSION} VERSION_GREATER 3.17.6)` to return true, and then cmake fails (because `CheckLinkerFlag` does not exist). This PR does the opposite check `VERSION_LESS` (since `VERSION_GREAT_OR_EQUAL` does not exist). This is affecting my `SpaceVecAlg` and `RBDyn` builds.