### PR TITLE
export SEARCH_FOR_BOOST_PYTHON

### DIFF
--- a/boost.cmake
+++ b/boost.cmake
@@ -125,8 +125,11 @@ macro(SEARCH_FOR_BOOST_PYTHON)
   endif(NOT BOOST_PYTHON_FOUND)
 
   if(PYTHON_EXPORT_DEPENDENCY)
-    add_project_dependency(Boost ${BOOST_PYTHON_REQUIRED} COMPONENTS
-                           ${BOOST_PYTHON_NAME})
+    install_jrl_cmakemodules_dir("boost")
+    install_jrl_cmakemodules_file("boost.cmake")
+    set(PYTHON_EXPORT_DEPENDENCY_MACROS
+        "${PYTHON_EXPORT_DEPENDENCY_MACROS}\nSEARCH_FOR_BOOST_PYTHON(${BOOST_PYTHON_REQUIRED})"
+    )
   else()
     find_package(Boost ${BOOST_PYTHON_REQUIRED} COMPONENTS ${BOOST_PYTHON_NAME})
   endif()

--- a/package-config.cmake
+++ b/package-config.cmake
@@ -281,3 +281,15 @@ macro(INSTALL_JRL_CMAKEMODULES_FILE filename)
       "${INCLUDE_INSTALLED_JRL_FILES}\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/${filename}\")"
   )
 endmacro()
+
+# .rst: .. command:: INSTALL_JRL_CMAKEMODULES_DIR (dirname)
+#
+# install jrl-cmakemodules/$dirname along CMake package exports
+#
+macro(INSTALL_JRL_CMAKEMODULES_DIR dirname)
+  install(DIRECTORY "${PROJECT_JRL_CMAKE_MODULE_DIR}/${dirname}"
+          DESTINATION "${CONFIG_INSTALL_DIR}")
+  set(INCLUDE_INSTALLED_JRL_FILES
+      "${INCLUDE_INSTALLED_JRL_FILES}\nset(CMAKE_MODULE_PATH \${CMAKE_CURRENT_LIST_DIR}/${dirname} \${CMAKE_MODULE_PATH})"
+  )
+endmacro()


### PR DESCRIPTION
For CMake < 3.12, we use upgraded version of FindBoost.cmake:

https://github.com/jrl-umi3218/jrl-cmakemodules/blob/f4e4be6a6f6577d86c9e2b09ae3a9bf1a545437e/boost.cmake#L40-L46

But then, when we export the Boost targets, they don't exists on dependent projects that don't have a similar workaround and try to link to our packages.

ref https://github.com/stack-of-tasks/eigenpy/pull/307