### PR TITLE
FindBoost: Change 'no header defined' WARNING to STATUS

### DIFF
--- a/boost/FindBoost.cmake
+++ b/boost/FindBoost.cmake
@@ -2222,7 +2222,7 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
     endif()
   else()
     set(Boost_${UPPERCOMPONENT}_HEADER ON)
-    message(WARNING "No header defined for ${COMPONENT}; skipping header check "
+    message(STATUS "No header defined for ${COMPONENT}; skipping header check "
                     "(note: header-only libraries have no designated component)")
   endif()
 


### PR DESCRIPTION
One more quite common warning that doesn't require user action, reducing it to a status message.