### PR TITLE
Release: edit version number in pyproject.toml

### DIFF
--- a/pyproject.py
+++ b/pyproject.py
@@ -5,7 +5,8 @@ try:
     import tomlkit
 except ImportError as e:
     print(
-        "tomlkit not found. Please make sure to install the package. If it is already installed, make sure that it is included in the search path."
+        "tomlkit not found. Please make sure to install the package.\n"
+        "If it is already installed, make sure that it is included in the search path."
     )
     raise e
 

--- a/pyproject.py
+++ b/pyproject.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 import sys
-
-import tomlkit
+try:
+    import tomlkit
+except ImportError as e:
+    print('tomlkit not found. Please make sure to install the package. If it is already installed, make sure that it is included in the search path.')
+    raise e
 
 
 def update_pyproject_version(version):
@@ -17,3 +20,4 @@ if __name__ == "__main__":
         update_pyproject_version(sys.argv[1])
     else:
         print("you must provide the version as argument.")
+        exit(1)

--- a/pyproject.py
+++ b/pyproject.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 import sys
+
 try:
     import tomlkit
 except ImportError as e:
-    print('tomlkit not found. Please make sure to install the package. If it is already installed, make sure that it is included in the search path.')
+    print(
+        "tomlkit not found. Please make sure to install the package. If it is already installed, make sure that it is included in the search path."
+    )
     raise e
 
 

--- a/pyproject.py
+++ b/pyproject.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import sys
+
+import tomlkit
+
+
+def update_pyproject_version(version):
+    with open("pyproject.toml") as f:
+        doc = tomlkit.load(f)
+    doc["project"]["version"] = version
+    with open("pyproject.toml", "w") as f:
+        tomlkit.dump(doc, f)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        update_pyproject_version(sys.argv[1])
+    else:
+        print("you must provide the version as argument.")

--- a/release.cmake
+++ b/release.cmake
@@ -88,7 +88,31 @@ macro(RELEASE_SETUP)
          "release: Update package.xml version to $$VERSION"
          &&
          echo
-         "Updated package.xml and committed") ; fi && ${GIT} tag -s v$$VERSION
+         "Updated package.xml and committed") ; fi
+        # Update version in pyproject.toml if it exists
+        && if [ -f "pyproject.toml" ]; then
+        (echo
+         "Updating pyproject.toml to $$VERSION"
+         &&
+         sed
+         -i.back
+         \'s|version = \".*\"|version = \"$$VERSION\"|g\'
+         pyproject.toml
+         &&
+         rm
+         pyproject.toml.back
+         &&
+         ${GIT}
+         add
+         pyproject.toml
+         &&
+         ${GIT}
+         commit
+         -m
+         "release: Update pyproject.toml version to $$VERSION"
+         &&
+         echo
+         "Updated pyproject.toml and committed") ; fi && ${GIT} tag -s v$$VERSION
         -m "Release of version $$VERSION." && cd ${CMAKE_BINARY_DIR} && cmake
         ${PROJECT_SOURCE_DIR} && make distcheck || (
                                                    echo

--- a/release.cmake
+++ b/release.cmake
@@ -94,13 +94,7 @@ macro(RELEASE_SETUP)
         (echo
          "Updating pyproject.toml to $$VERSION"
          &&
-         sed
-         -i.back
-         \'s|version = \".*\"|version = \"$$VERSION\"|g\'
-         pyproject.toml
-         &&
-         rm
-         pyproject.toml.back
+         ${PYTHON_EXECUTABLE} ${PROJECT_JRL_CMAKE_MODULE_DIR}/pyproject.py $$VERSION
          &&
          ${GIT}
          add

--- a/release.cmake
+++ b/release.cmake
@@ -94,7 +94,9 @@ macro(RELEASE_SETUP)
         (echo
          "Updating pyproject.toml to $$VERSION"
          &&
-         ${PYTHON_EXECUTABLE} ${PROJECT_JRL_CMAKE_MODULE_DIR}/pyproject.py $$VERSION
+         ${PYTHON_EXECUTABLE}
+         ${PROJECT_JRL_CMAKE_MODULE_DIR}/pyproject.py
+         $$VERSION
          &&
          ${GIT}
          add
@@ -106,28 +108,27 @@ macro(RELEASE_SETUP)
          "release: Update pyproject.toml version to $$VERSION"
          &&
          echo
-         "Updated pyproject.toml and committed") ; fi && ${GIT} tag -s v$$VERSION
-        -m "Release of version $$VERSION." && cd ${CMAKE_BINARY_DIR} && cmake
-        ${PROJECT_SOURCE_DIR} && make distcheck || (
-                                                   echo
-                                                   "Please fix distcheck first."
-                                                   &&
-                                                   cd
-                                                   ${PROJECT_SOURCE_DIR}
-                                                   &&
-                                                   ${GIT}
-                                                   tag
-                                                   -d
-                                                   v$$VERSION
-                                                   &&
-                                                   cd
-                                                   ${CMAKE_BINARY_DIR}
-                                                   &&
-                                                   cmake
-                                                   ${PROJECT_SOURCE_DIR}
-                                                   &&
-                                                   false) && make dist && make
-        distclean && echo
+         "Updated pyproject.toml and committed") ; fi && ${GIT} tag -s
+        v$$VERSION -m "Release of version $$VERSION." && cd ${CMAKE_BINARY_DIR}
+        && cmake ${PROJECT_SOURCE_DIR} && make distcheck ||
+        (echo
+         "Please fix distcheck first."
+         &&
+         cd
+         ${PROJECT_SOURCE_DIR}
+         &&
+         ${GIT}
+         tag
+         -d
+         v$$VERSION
+         &&
+         cd
+         ${CMAKE_BINARY_DIR}
+         &&
+         cmake
+         ${PROJECT_SOURCE_DIR}
+         &&
+         false) && make dist && make distclean && echo
         "Please, run 'git push --tags' and upload the tarball to github to finalize this release."
     )
   endif()


### PR DESCRIPTION
Automatically set the version number in the `pyproject.toml` file, similar to what's done for the `package.xml` . This is useful for projects like [proxsuite](https://github.com/simple-robotics/proxsuite) that use [cmeel](https://github.com/cmake-wheel/cmeel).