### PR TITLE
Automatically uninstall before install

### DIFF
--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -16,7 +16,7 @@
 # This files comes from the CMake FAQ: http://www.cmake.org/Wiki/CMake_FAQ
 cmake_policy(SET CMP0007 NEW)
 IF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
-  MESSAGE(FATAL_ERROR "Cannot find install manifest:\"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
+  RETURN()
 ENDIF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
 
 MESSAGE(STATUS "catkin path: @CMAKE_INSTALL_PREFIX@/.catkin")
@@ -30,7 +30,9 @@ IF(EXISTS "@CMAKE_INSTALL_PREFIX@/.catkin")
        )
 ENDIF(EXISTS "@CMAKE_INSTALL_PREFIX@/.catkin")
 
-
+IF(EXISTS "@CMAKE_CURRRENT_BINARY_DIR@/install_manifest.txt")
+  return()
+ENDIF()
 FILE(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
 STRING(REGEX REPLACE "\n" ";" files "${files}")
 LIST(REMOVE_ITEM files "")

--- a/uninstall.cmake
+++ b/uninstall.cmake
@@ -47,3 +47,10 @@ macro(_SETUP_PROJECT_UNINSTALL)
     "${CMAKE_COMMAND}" -P
     "${PROJECT_BINARY_DIR}/cmake/$<CONFIGURATION>/cmake_reinstall.cmake")
 endmacro(_SETUP_PROJECT_UNINSTALL)
+
+# We setup the auto-uninstall target here, it is early enough that we can ensure
+# it is going to be called first See the first paragraph here
+# https://cmake.org/cmake/help/latest/command/install.html#introduction
+install(
+  CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${PROJECT_BINARY_DIR}\" --config \${CMAKE_INSTALL_CONFIG_NAME} --target uninstall)"
+)


### PR DESCRIPTION
This PR automatically calls `uninstall` before an install command is called.

- The motivation is to avoid keeping stale libraries and obsolete header files around
- This relies on the documented fact that `install` commands are run in the specified order, hence the "hook" is setup early, normally before any call to `install` in user code happened (i.e. as long as you don't have `install` commands before `include(base.cmake)` it should work
- it changes the behavior of the uninstall target so that it doesn't print an error message if called before install (for the first time)

Since it's an impactful change I will wait for feedback (@nim65s @jcarpent @wxmerkt in particular) before merging