### PR TITLE
pyproject.py: check project / version exist

### DIFF
--- a/pyproject.py
+++ b/pyproject.py
@@ -14,6 +14,9 @@ except ImportError as e:
 def update_pyproject_version(version):
     with open("pyproject.toml") as f:
         doc = tomlkit.load(f)
+    if "project" not in doc or "version" not in doc["project"]:
+        print("pyproject.toml doesn't contain project / version")
+        return
     doc["project"]["version"] = version
     with open("pyproject.toml", "w") as f:
         tomlkit.dump(doc, f)

--- a/release.cmake
+++ b/release.cmake
@@ -2,7 +2,8 @@
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later version.
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
@@ -59,50 +60,68 @@ macro(RELEASE_SETUP)
     add_custom_target(
       release_package_xml
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      COMMAND echo "Updating package.xml to $$VERSION"
-      && sed -i.back \"s|<version>.*</version>|<version>$$VERSION</version>|g\" package.xml
-      && rm package.xml.back
-      && ${GIT} add package.xml
-      && ${GIT} commit -m "release: Update package.xml version to $$VERSION"
-      && echo "Updated package.xml and committed")
+      COMMAND
+        echo "Updating package.xml to $$VERSION" && sed -i.back
+        \"s|<version>.*</version>|<version>$$VERSION</version>|g\" package.xml
+        && rm package.xml.back && ${GIT} add package.xml && ${GIT} commit -m
+        "release: Update package.xml version to $$VERSION" && echo
+        "Updated package.xml and committed")
 
     add_custom_target(
       release_pyproject_toml
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      COMMAND echo "Updating pyproject.toml to $$VERSION"
-      && ${PYTHON_EXECUTABLE} ${PROJECT_JRL_CMAKE_MODULE_DIR}/pyproject.py $$VERSION
-      && if ! (git diff --quiet pyproject.toml) ; then
-      (${GIT} add pyproject.toml
-      && ${GIT} commit -m "release: Update pyproject.toml version to $$VERSION"
-      && echo "Updated pyproject.toml and committed") ; fi)
+      COMMAND
+        echo "Updating pyproject.toml to $$VERSION" && ${PYTHON_EXECUTABLE}
+        ${PROJECT_JRL_CMAKE_MODULE_DIR}/pyproject.py $$VERSION && if !
+        (git diff --quiet pyproject.toml) ; then
+        (${GIT}
+         add
+         pyproject.toml
+         &&
+         ${GIT}
+         commit
+         -m
+         "release: Update pyproject.toml version to $$VERSION"
+         &&
+         echo
+         "Updated pyproject.toml and committed") ; fi)
 
-      add_custom_target(
-        release
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        COMMAND
-        export LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}
-        && export ${LD_LIBRARY_PATH_VARIABLE_NAME}=$ENV{${LD_LIBRARY_PATH_VARIABLE_NAME}}
-        && export PYTHONPATH=$ENV{PYTHONPATH}
-        && ! test x$$VERSION = x || (echo "Please set a version for this release" && false)
-        # Update version in package.xml if it exists
-        && if [ -f "package.xml" ]; then (make -C ${CMAKE_BINARY_DIR} release_package_xml) ; fi
+    add_custom_target(
+      release
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      COMMAND
+        export LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH} && export
+        ${LD_LIBRARY_PATH_VARIABLE_NAME}=$ENV{${LD_LIBRARY_PATH_VARIABLE_NAME}}
+        && export PYTHONPATH=$ENV{PYTHONPATH} && ! test x$$VERSION = x ||
+        (echo "Please set a version for this release" && false) # Update version
+                                                                # in package.xml
+                                                                # if it exists
+        && if [ -f "package.xml" ]; then (make -C ${CMAKE_BINARY_DIR}
+                                          release_package_xml) ; fi
         # Update version in pyproject.toml if it exists
-        && if [ -f "pyproject.toml" ]; then (make -C ${CMAKE_BINARY_DIR} release_pyproject_toml) ; fi
-        && ${GIT} tag -s v$$VERSION -m "Release of version $$VERSION."
-        && cd ${CMAKE_BINARY_DIR}
-        && cmake ${PROJECT_SOURCE_DIR}
-        && make distcheck
-        || (
-          echo "Please fix distcheck first."
-          && cd ${PROJECT_SOURCE_DIR}
-          && ${GIT} tag -d v$$VERSION
-          && cd ${CMAKE_BINARY_DIR}
-          && cmake ${PROJECT_SOURCE_DIR}
-          && false
-        )
-        && make dist
-        && make distclean
-        && echo "Please, run 'git push --tags' and upload the tarball to github to finalize this release."
+        && if [ -f "pyproject.toml" ]; then (make -C ${CMAKE_BINARY_DIR}
+                                             release_pyproject_toml) ; fi &&
+        ${GIT} tag -s v$$VERSION -m "Release of version $$VERSION." && cd
+        ${CMAKE_BINARY_DIR} && cmake ${PROJECT_SOURCE_DIR} && make distcheck ||
+        (echo
+         "Please fix distcheck first."
+         &&
+         cd
+         ${PROJECT_SOURCE_DIR}
+         &&
+         ${GIT}
+         tag
+         -d
+         v$$VERSION
+         &&
+         cd
+         ${CMAKE_BINARY_DIR}
+         &&
+         cmake
+         ${PROJECT_SOURCE_DIR}
+         &&
+         false) && make dist && make distclean && echo
+        "Please, run 'git push --tags' and upload the tarball to github to finalize this release."
     )
   endif()
 endmacro()

--- a/release.cmake
+++ b/release.cmake
@@ -2,8 +2,7 @@
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later
-# version.
+# Foundation, either version 3 of the License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
@@ -58,78 +57,52 @@ macro(RELEASE_SETUP)
     endif(APPLE)
 
     add_custom_target(
-      release
-      COMMAND
-        export LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH} && export
-        ${LD_LIBRARY_PATH_VARIABLE_NAME}=$ENV{${LD_LIBRARY_PATH_VARIABLE_NAME}}
-        && export PYTHONPATH=$ENV{PYTHONPATH} && ! test x$$VERSION = x ||
-        (echo "Please set a version for this release" && false) && cd
-        ${PROJECT_SOURCE_DIR}
+      release_package_xml
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      COMMAND echo "Updating package.xml to $$VERSION"
+      && sed -i.back \"s|<version>.*</version>|<version>$$VERSION</version>|g\" package.xml
+      && rm package.xml.back
+      && ${GIT} add package.xml
+      && ${GIT} commit -m "release: Update package.xml version to $$VERSION"
+      && echo "Updated package.xml and committed")
+
+    add_custom_target(
+      release_pyproject_toml
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      COMMAND echo "Updating pyproject.toml to $$VERSION"
+      && ${PYTHON_EXECUTABLE} ${PROJECT_JRL_CMAKE_MODULE_DIR}/pyproject.py $$VERSION
+      && if ! (git diff --quiet pyproject.toml) ; then
+      (${GIT} add pyproject.toml
+      && ${GIT} commit -m "release: Update pyproject.toml version to $$VERSION"
+      && echo "Updated pyproject.toml and committed") ; fi)
+
+      add_custom_target(
+        release
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMAND
+        export LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}
+        && export ${LD_LIBRARY_PATH_VARIABLE_NAME}=$ENV{${LD_LIBRARY_PATH_VARIABLE_NAME}}
+        && export PYTHONPATH=$ENV{PYTHONPATH}
+        && ! test x$$VERSION = x || (echo "Please set a version for this release" && false)
         # Update version in package.xml if it exists
-        && if [ -f "package.xml" ]; then
-        (echo
-         "Updating package.xml to $$VERSION"
-         &&
-         sed
-         -i.back
-         \"s|<version>.*</version>|<version>$$VERSION</version>|g\"
-         package.xml
-         &&
-         rm
-         package.xml.back
-         &&
-         ${GIT}
-         add
-         package.xml
-         &&
-         ${GIT}
-         commit
-         -m
-         "release: Update package.xml version to $$VERSION"
-         &&
-         echo
-         "Updated package.xml and committed") ; fi
+        && if [ -f "package.xml" ]; then (make -C ${CMAKE_BINARY_DIR} release_package_xml) ; fi
         # Update version in pyproject.toml if it exists
-        && if [ -f "pyproject.toml" ]; then
-        (echo
-         "Updating pyproject.toml to $$VERSION"
-         &&
-         ${PYTHON_EXECUTABLE}
-         ${PROJECT_JRL_CMAKE_MODULE_DIR}/pyproject.py
-         $$VERSION
-         &&
-         ${GIT}
-         add
-         pyproject.toml
-         &&
-         ${GIT}
-         commit
-         -m
-         "release: Update pyproject.toml version to $$VERSION"
-         &&
-         echo
-         "Updated pyproject.toml and committed") ; fi && ${GIT} tag -s
-        v$$VERSION -m "Release of version $$VERSION." && cd ${CMAKE_BINARY_DIR}
-        && cmake ${PROJECT_SOURCE_DIR} && make distcheck ||
-        (echo
-         "Please fix distcheck first."
-         &&
-         cd
-         ${PROJECT_SOURCE_DIR}
-         &&
-         ${GIT}
-         tag
-         -d
-         v$$VERSION
-         &&
-         cd
-         ${CMAKE_BINARY_DIR}
-         &&
-         cmake
-         ${PROJECT_SOURCE_DIR}
-         &&
-         false) && make dist && make distclean && echo
-        "Please, run 'git push --tags' and upload the tarball to github to finalize this release."
+        && if [ -f "pyproject.toml" ]; then (make -C ${CMAKE_BINARY_DIR} release_pyproject_toml) ; fi
+        && ${GIT} tag -s v$$VERSION -m "Release of version $$VERSION."
+        && cd ${CMAKE_BINARY_DIR}
+        && cmake ${PROJECT_SOURCE_DIR}
+        && make distcheck
+        || (
+          echo "Please fix distcheck first."
+          && cd ${PROJECT_SOURCE_DIR}
+          && ${GIT} tag -d v$$VERSION
+          && cd ${CMAKE_BINARY_DIR}
+          && cmake ${PROJECT_SOURCE_DIR}
+          && false
+        )
+        && make dist
+        && make distclean
+        && echo "Please, run 'git push --tags' and upload the tarball to github to finalize this release."
     )
   endif()
 endmacro()


### PR DESCRIPTION
Hi,

On projects with a `pyproject.toml` file without a `project` key with a `version` inside, `make release` is currently failing with:
```
╰─>$ make -sj3 release VERSION=4.0.10
Updating package.xml to 4.0.10
[devel 3f41a9f] release: Update package.xml version to 4.0.10
 1 file changed, 1 insertion(+), 1 deletion(-)
Updated package.xml and committed
Updating pyproject.toml to 4.0.10
Traceback (most recent call last):
  File "…/cmake/pyproject.py", line 24, in <module>
    update_pyproject_version(sys.argv[1])
  File "…/cmake/pyproject.py", line 17, in update_pyproject_version
    doc["project"]["version"] = version
  File "/usr/lib/python3.10/site-packages/tomlkit/container.py", line 650, in __getitem__
    raise NonExistentKey(key)
tomlkit.exceptions.NonExistentKey: 'Key "project" does not exist.'
Please fix distcheck first.
error: étiquette 'v4.0.10' non trouvée.
```

This can easily happen for projects using `pyproject.toml` only to configure some python tooling, but not to ship project metadata or packaging info.