### PR TITLE
deprecated.hh.cmake: Only define PROJECT_PRAGMA if not yet defined

### DIFF
--- a/deprecated.hh.cmake
+++ b/deprecated.hh.cmake
@@ -40,7 +40,9 @@
 # endif // __cplusplus
 
 # if defined(__GNUC__) || defined(__clang__)
-#  define @PACKAGE_CPPNAME@_PRAGMA(X) _Pragma(#X)
+#  ifndef @PACKAGE_CPPNAME@_PRAGMA
+#   define @PACKAGE_CPPNAME@_PRAGMA(X) _Pragma(#X)
+#  endif
 #  define @PACKAGE_CPPNAME@_DEPRECATED_HEADER(MSG) @PACKAGE_CPPNAME@_PRAGMA(GCC warning MSG)
 # elif defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #  define @PACKAGE_CPPNAME@_STRINGIZE_(MSG) #MSG


### PR DESCRIPTION
E.g. Pinocchio defines its own redundant `PINOCCHIO_PRAGMA`. This results in hundreds of warnings -- checking and only defining if required fixes this issue. Alternatively we could force undef here, but I don't think that's a good idea.