### PR TITLE
hpp/idl: remove useless import

### DIFF
--- a/hpp/idl/omniidl_be_python_with_docstring.py
+++ b/hpp/idl/omniidl_be_python_with_docstring.py
@@ -112,7 +112,7 @@ class CommentToConstVisitor(idlvisitor.AstVisitor):
             elif isinstance(parent, idlast.AST):
                 parent._AST__declarations.append(const)
             else:
-                print("Doc ignored: " + comment.text())
+                print("%s:%s: warning: doc ignored" % (node.file(), node.line()))
 
     def visitAST(self, node):
         for n in node.declarations():

--- a/hpp/idl/omniidl_be_python_with_docstring.py
+++ b/hpp/idl/omniidl_be_python_with_docstring.py
@@ -24,7 +24,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from omniidl_be.python import comment, output_inline
+from omniidl_be.python import output_inline
 from omniidl_be.python import run as run_parent
 from omniidl import idlvisitor, idlast, idltype
 


### PR DESCRIPTION
Hi,

Trying to release hpp-corbaserver, I got the following error:

```
omniidl: Could not import back-end 'omniidl_be_python_with_docstring'
omniidl: Maybe you need to use the -p option?
omniidl: (The error was 'No module named 'omniidl_be.omniidl_be_python_with_docstring'')
```

I have no idea why, but removing an unused import fixed the issue.

@jmirabel : you added this file in #194, so if you have a better understanding of the issue, or have a better idea, that's welcome. 
Otherwise, I think this change couldn't harm anyway, so we can just merge this and don't loose any time here.