### PR TITLE
FindSimde: use hint for failure only for cmake > 3.15

### DIFF
--- a/find-external/Simde/FindSimde.cmake
+++ b/find-external/Simde/FindSimde.cmake
@@ -19,7 +19,8 @@ else()
   find_package_handle_standard_args(
     Simde
     FOUND_VAR Simde_FOUND
-    REQUIRED_VARS Simde_INCLUDE_DIR REASON_FAILURE_MESSAGE ${SIMDE_HINT_FAILURE})
+    REQUIRED_VARS Simde_INCLUDE_DIR REASON_FAILURE_MESSAGE
+                  ${SIMDE_HINT_FAILURE})
 endif()
 
 if(Simde_FOUND)

--- a/find-external/Simde/FindSimde.cmake
+++ b/find-external/Simde/FindSimde.cmake
@@ -8,11 +8,19 @@ if(NOT SIMDE_HINT_FAILURE)
   set(SIMDE_HINT_FAILURE None)
 endif()
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-  Simde
-  FOUND_VAR Simde_FOUND
-  REQUIRED_VARS Simde_INCLUDE_DIR REASON_FAILURE_MESSAGE ${SIMDE_HINT_FAILURE})
+if(${CMAKE_VERSION} VERSION_LESS "3.16.0")
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    Simde
+    FOUND_VAR Simde_FOUND
+    REQUIRED_VARS Simde_INCLUDE_DIR)
+else()
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    Simde
+    FOUND_VAR Simde_FOUND
+    REQUIRED_VARS Simde_INCLUDE_DIR REASON_FAILURE_MESSAGE ${SIMDE_HINT_FAILURE})
+endif()
 
 if(Simde_FOUND)
   add_library(simde INTERFACE IMPORTED)


### PR DESCRIPTION
`REASON_FAILURE_MESSAGE` was only introduced in cmake v3.16.