### PR TITLE
Make FindqpOASES compatible with other distros than linux

### DIFF
--- a/find-external/qpOASES/FindqpOASES.cmake
+++ b/find-external/qpOASES/FindqpOASES.cmake
@@ -28,7 +28,7 @@ find_path(
   PATHS ${qpOASES_PREFIX} ${qpOASES_PREFIX}/include)
 find_library(
   qpOASES_LIBRARY
-  NAMES libqpOASES.so libqpOASES.dylib qpOASES.lib
+  NAMES qpOASES
   PATHS ${qpOASES_PREFIX} ${qpOASES_PREFIX}/lib)
 
 set(qpOASES_LIBRARIES ${qpOASES_LIBRARY})

--- a/find-external/qpOASES/FindqpOASES.cmake
+++ b/find-external/qpOASES/FindqpOASES.cmake
@@ -28,7 +28,7 @@ find_path(
   PATHS ${qpOASES_PREFIX} ${qpOASES_PREFIX}/include)
 find_library(
   qpOASES_LIBRARY
-  NAMES libqpOASES.so
+  NAMES libqpOASES.so libqpOASES.dylib qpOASES.lib
   PATHS ${qpOASES_PREFIX} ${qpOASES_PREFIX}/lib)
 
 set(qpOASES_LIBRARIES ${qpOASES_LIBRARY})


### PR DESCRIPTION
Make FindqpOASES compatible with other distros than linux

Adding other names with the other extensions possibles.

Best,
Yann