### PR TITLE
avoid multiple findpython() calls

### DIFF
--- a/python.cmake
+++ b/python.cmake
@@ -339,9 +339,13 @@ macro(FINDPYTHON)
 
   if(PYTHON_EXPORT_DEPENDENCY)
     install_jrl_cmakemodules_file("python.cmake")
-    string(CONCAT PYTHON_EXPORT_DEPENDENCY_MACROS
-                  "list(APPEND PYTHON_COMPONENTS ${PYTHON_COMPONENTS})\n"
-                  "list(REMOVE_DUPLICATES PYTHON_COMPONENTS)\n" "FINDPYTHON()")
+    string(
+      CONCAT PYTHON_EXPORT_DEPENDENCY_MACROS
+             "list(APPEND PYTHON_COMPONENTS ${PYTHON_COMPONENTS})\n"
+             "list(REMOVE_DUPLICATES PYTHON_COMPONENTS)\n"
+             "if(NOT FINDPYTHON_ALREADY_CALLED)"
+             "FINDPYTHON()"
+             "endif()")
   endif()
 
   if(SEARCH_FOR_NUMPY)

--- a/python.cmake
+++ b/python.cmake
@@ -343,9 +343,9 @@ macro(FINDPYTHON)
       CONCAT PYTHON_EXPORT_DEPENDENCY_MACROS
              "list(APPEND PYTHON_COMPONENTS ${PYTHON_COMPONENTS})\n"
              "list(REMOVE_DUPLICATES PYTHON_COMPONENTS)\n"
-             "if(NOT FINDPYTHON_ALREADY_CALLED)"
-             "FINDPYTHON()"
-             "endif()")
+             "if(NOT FINDPYTHON_ALREADY_CALLED)\n"
+             "FINDPYTHON()\n"
+             "endif()\n")
   endif()
 
   if(SEARCH_FOR_NUMPY)


### PR DESCRIPTION
Hi, 

This add a guard in exported modules to avoid multiple ones calling successive findpython(), which can fail (for a yet unknown reason).

This is required when package A and B are independant and use and export findpython(), and package C depends on both.

eg. hpp-gepetto-viewer configuration fails, because its `add_project_dependency("hpp-corbaserver")` calls `findpython()`, and then `add_project_dependency("gepetto-viewer")` calls it again, and fail.