### PR TITLE
base: displaying which project is currently being configured

### DIFF
--- a/base.cmake
+++ b/base.cmake
@@ -164,6 +164,8 @@ foreach(VARIABLE ${REQUIRED_VARIABLES})
   endif(NOT DEFINED ${VARIABLE})
 endforeach(VARIABLE)
 
+message(STATUS "Configuring \"${PROJECT_NAME}\" (${PROJECT_URL})")
+
 # If the project version number is not set, compute it automatically.
 if(NOT DEFINED PROJECT_VERSION)
   version_compute()


### PR DESCRIPTION
Hi,

Looking at logs of many projects configuring at once is a bit hard because we never know which is the current one.
Here is a trivial helper for this case.