### PR TITLE
stubs: allow user to supply name of dependent target to generate_stubs()

### DIFF
--- a/stubs.cmake
+++ b/stubs.cmake
@@ -58,8 +58,8 @@ endmacro(LOAD_STUBGEN)
 
 # .rst: .. command:: LOAD_STUBGEN(module_path module_name module_install_dir)
 #
-# Generate the stubs associated to a given project. If the TARGET python exists,
-# then the stubs generation will be performed after python target.
+# Generate the stubs associated to a given project. If optional arguments (which should
+# be CMake targets) are supplied, then the stubs will only be generated after every specified target is built.
 #
 # .rst: .. variable:: module_path
 #
@@ -103,9 +103,15 @@ function(GENERATE_STUBS module_path module_name module_install_dir)
       "--boost-python" --ignore-invalid signature "--no-setup-py"
       "--root-module-suffix" ""
     VERBATIM)
-  if(TARGET python)
-    add_dependencies(${target_name} python)
-  endif(TARGET python)
+  set(optional_args ${ARGN})
+  foreach(py_target IN LISTS optional_args)
+    if(TARGET ${py_target})
+      message(STATUS "generate_stubs: adding dependency on ${py_target}. Stubs will be generated after it is built.")
+      add_dependencies(${target_name} ${py_target})
+    else(TARGET ${py_target})
+      message(WARNING "generate_stubs: target ${py_target} not known.")
+    endif(TARGET ${py_target})
+  endforeach()
 
   install(
     DIRECTORY ${module_path}/${module_name}

--- a/stubs.cmake
+++ b/stubs.cmake
@@ -58,8 +58,9 @@ endmacro(LOAD_STUBGEN)
 
 # .rst: .. command:: LOAD_STUBGEN(module_path module_name module_install_dir)
 #
-# Generate the stubs associated to a given project. If optional arguments (which should
-# be CMake targets) are supplied, then the stubs will only be generated after every specified target is built.
+# Generate the stubs associated to a given project. If optional arguments (which
+# should be CMake targets) are supplied, then the stubs will only be generated
+# after every specified target is built.
 #
 # .rst: .. variable:: module_path
 #
@@ -106,7 +107,10 @@ function(GENERATE_STUBS module_path module_name module_install_dir)
   set(optional_args ${ARGN})
   foreach(py_target IN LISTS optional_args)
     if(TARGET ${py_target})
-      message(STATUS "generate_stubs: adding dependency on ${py_target}. Stubs will be generated after it is built.")
+      message(
+        STATUS
+          "generate_stubs: adding dependency on ${py_target}. Stubs will be generated after it is built."
+      )
       add_dependencies(${target_name} ${py_target})
     else(TARGET ${py_target})
       message(WARNING "generate_stubs: target ${py_target} not known.")


### PR DESCRIPTION
Supplying python bindings target name ensures stubgen doesn't import a target that's not built yet.

Before, stubgen used to check if a target named "python" existed. This PR allows the user to give a list of optional arguments, each of which are checked to be an existing target and then appended to the stubgen target's dependencies.

Resolves #584

This should also fix stack-of-tasks/pinocchio/issues/1879