### PR TITLE
Add relpath.cmake

### DIFF
--- a/base.cmake
+++ b/base.cmake
@@ -142,6 +142,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/oscheck.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cxx-standard.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/coverage.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/modernize-links.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/relpath.cmake)
 
 # --------- # Constants # --------- #
 

--- a/pkg-config.cmake
+++ b/pkg-config.cmake
@@ -53,10 +53,9 @@ set(PKG_CONFIG_ADDITIONAL_VARIABLES bindir pkglibdir datarootdir pkgdatarootdir
 #
 macro(_SETUP_PROJECT_PKG_CONFIG)
   # Pkg-config related commands.
-  rel_inv_install_path("${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-                       _PC_REL_INV_INSTALL_PATH)
+  rel_install_path("${CMAKE_INSTALL_LIBDIR}/pkgconfig" _PC_REL_INSTALL_PATH)
   set(_PKG_CONFIG_PREFIX
-      "\${pcfiledir}/${_PC_REL_INV_INSTALL_PATH}"
+      "\${pcfiledir}/${_PC_REL_INSTALL_PATH}"
       CACHE INTERNAL "")
   set(_PKG_CONFIG_EXEC_PREFIX
       "${_PKG_CONFIG_PREFIX}"

--- a/pkg-config.cmake
+++ b/pkg-config.cmake
@@ -53,15 +53,10 @@ set(PKG_CONFIG_ADDITIONAL_VARIABLES bindir pkglibdir datarootdir pkgdatarootdir
 #
 macro(_SETUP_PROJECT_PKG_CONFIG)
   # Pkg-config related commands.
-  if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
-    file(RELATIVE_PATH _PKG_CONFIG_RELATIVE_INSTALL_DIR
-         "${CMAKE_INSTALL_LIBDIR}/pkgconfig" ${CMAKE_INSTALL_PREFIX})
-  else()
-    string(REGEX REPLACE "[^/]+" ".." _PKG_CONFIG_RELATIVE_INSTALL_DIR
-                         "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-  endif()
+  rel_inv_install_path("${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+                       _PC_REL_INV_INSTALL_PATH)
   set(_PKG_CONFIG_PREFIX
-      "\${pcfiledir}/${_PKG_CONFIG_RELATIVE_INSTALL_DIR}"
+      "\${pcfiledir}/${_PC_REL_INV_INSTALL_PATH}"
       CACHE INTERNAL "")
   set(_PKG_CONFIG_EXEC_PREFIX
       "${_PKG_CONFIG_PREFIX}"

--- a/relpath.cmake
+++ b/relpath.cmake
@@ -6,12 +6,13 @@
 
 # .rst: .. ifmode:: user
 #
-# .. command:: REL_INV_INSTALL_PATH(FILE VARIABLE)
+# .. command:: REL_INSTALL_PATH(FILE VARIABLE)
 #
-# Compute the relative path from FILE to installation prefix. Works for relative
-# and absolute FILE, except for absolute paths outside of CMAKE_INSTALL_PREFIX.
+# Compute the relative path from the installation prefix to FILE. Works for
+# relative and absolute FILE, except for absolute paths outside of
+# CMAKE_INSTALL_PREFIX.
 #
-macro(REL_INV_INSTALL_PATH FILE VARIABLE)
+macro(REL_INSTALL_PATH FILE VARIABLE)
   if(IS_ABSOLUTE ${FILE})
     file(RELATIVE_PATH _VARIABLE "${FILE}" ${CMAKE_INSTALL_PREFIX})
     string(REGEX REPLACE "/$" "" ${VARIABLE} "${_VARIABLE}")
@@ -22,21 +23,21 @@ endmacro()
 
 # .rst: .. ifmode:: user
 #
-# .. command:: LIB_REL_RPATH(TARGET_INSTALL_DIR VARIABLE)
+# .. command:: REL_RPATH(TARGET_INSTALL_DIR VARIABLE)
 #
 # Provide INSTALL_RPATH from TARGET_INSTALL_DIR to CMAKE_INSTALL_LIBDIR as
 # relative to $ORIGIN / @loader_path. Works for relative and absolute
 # TARGET_INSTALL_DIR and CMAKE_INSTALL_LIBDIR, except for absolute paths outside
 # of CMAKE_INSTALL_PREFIX. Only on UNIX systems (including APPLE).
 #
-macro(LIB_REL_RPATH TARGET_INSTALL_DIR VARIABLE)
+macro(REL_RPATH TARGET_INSTALL_DIR VARIABLE)
   if(UNIX)
     if(APPLE)
       set(ORIGIN "@loader_path")
     else()
       set(ORIGIN "\$ORIGIN")
     endif()
-    rel_inv_install_path("${TARGET_INSTALL_DIR}" _TGT_INV_REL)
+    rel_install_path("${TARGET_INSTALL_DIR}" _TGT_INV_REL)
     if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
       file(RELATIVE_PATH _LIB_REL "${CMAKE_INSTALL_PREFIX}"
            ${CMAKE_INSTALL_LIBDIR})

--- a/relpath.cmake
+++ b/relpath.cmake
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2023 LAAS-CNRS
+#
+# Author: Guilhem Saurel
+#
+
+# .rst: .. ifmode:: user
+#
+# .. command:: REL_INV_INSTALL_PATH(FILE VARIABLE)
+#
+# Compute the relative path from FILE to installation prefix. Works for relative
+# and absolute FILE, except for absolute paths outside of CMAKE_INSTALL_PREFIX.
+#
+macro(REL_INV_INSTALL_PATH FILE VARIABLE)
+  if(IS_ABSOLUTE ${FILE})
+    file(RELATIVE_PATH _VARIABLE "${FILE}" ${CMAKE_INSTALL_PREFIX})
+    string(REGEX REPLACE "/$" "" ${VARIABLE} "${_VARIABLE}")
+  else()
+    string(REGEX REPLACE "[^/]+" ".." ${VARIABLE} "${FILE}")
+  endif()
+endmacro()
+
+# .rst: .. ifmode:: user
+#
+# .. command:: LIB_REL_RPATH(TARGET_INSTALL_DIR VARIABLE)
+#
+# Provide INSTALL_RPATH from TARGET_INSTALL_DIR to CMAKE_INSTALL_LIBDIR as
+# relative to $ORIGIN / @loader_path. Works for relative and absolute
+# TARGET_INSTALL_DIR and CMAKE_INSTALL_LIBDIR, except for absolute paths outside
+# of CMAKE_INSTALL_PREFIX. Only on UNIX systems (including APPLE).
+#
+macro(LIB_REL_RPATH TARGET_INSTALL_DIR VARIABLE)
+  if(UNIX)
+    if(APPLE)
+      set(ORIGIN "@loader_path")
+    else()
+      set(ORIGIN "\$ORIGIN")
+    endif()
+    rel_inv_install_path("${TARGET_INSTALL_DIR}" _TGT_INV_REL)
+    if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+      file(RELATIVE_PATH _LIB_REL "${CMAKE_INSTALL_PREFIX}"
+           ${CMAKE_INSTALL_LIBDIR})
+    else()
+      set(_LIB_REL ${CMAKE_INSTALL_LIBDIR})
+    endif()
+    set(${VARIABLE} "${ORIGIN}/${_TGT_INV_REL}/${_LIB_REL}")
+  endif()
+endmacro()


### PR DESCRIPTION
with `REL_INV_INSTALL_PATH(FILE VARIABLE)` to compute the relative inverse install path of `FILE` and store it into `VARIABLE`

eg:

```cmake
rel_inv_install_path("${CMAKE_INSTALL_LIBDIR}/pkgconfig" _PC_REL_INV_INSTALL_PATH)
set(_PKG_CONFIG_PREFIX "\${pcfiledir}/${_PC_REL_INV_INSTALL_PATH}")
```

and `LIB_REL_RPATH(TARGET_INSTALL_DIR VARIABLE)` to compute the relative path from this `TARGET_INSTALL_DIR` to `CMAKE_INSTALL_LIBDIR`."

eg:

```cmake
set(${PYWRAP}_INSTALL_DIR ${PYTHON_SITELIB}/${PROJECT_NAME})

if(UNIX)
  lib_rel_rpath(${${PYWRAP}_INSTALL_DIR} ${PYWRAP}_INSTALL_RPATH)
  set_target_properties(${PYWRAP} PROPERTIES INSTALL_RPATH "${${PYWRAP}_INSTALL_RPATH}")
endif()

install(TARGETS ${PYWRAP} DESTINATION ${${PYWRAP}_INSTALL_DIR})
```

fix. https://github.com/stack-of-tasks/eigenpy/issues/353 ref. https://github.com/jrl-umi3218/jrl-cmakemodules/pull/587