### PR TITLE
Fix relative path issues for doc

### DIFF
--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2008-2014 LAAS-CNRS, JRL AIST-CNRS.
+# Copyright (C) 2008-2023 LAAS-CNRS, JRL AIST-CNRS, INRIA.
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -675,6 +675,7 @@ macro(_SETUP_PROJECT_DOCUMENTATION_FINALIZE)
     if(INSTALL_DOCUMENTATION)
       # Find doxytag files To ignore this list of tag files, set variable
       # DOXYGEN_TAGFILES
+      set(INSTALL_DOCDIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR})
       set(PKG_REQUIRES ${_PKG_CONFIG_REQUIRES})
       list(APPEND PKG_REQUIRES ${_PKG_CONFIG_COMPILE_TIME_REQUIRES})
       foreach(PKG_CONFIG_STRING ${PKG_REQUIRES})
@@ -683,7 +684,7 @@ macro(_SETUP_PROJECT_DOCUMENTATION_FINALIZE)
         # If DOXYGENDOCDIR is specified, add a doc path.
         if(DEFINED ${PREFIX}_DOXYGENDOCDIR
            AND EXISTS ${${PREFIX}_DOXYGENDOCDIR}/${LIBRARY_NAME}.doxytag)
-          file(RELATIVE_PATH DEP_DOCDIR ${_PKG_CONFIG_DOXYGENDOCDIR}
+          file(RELATIVE_PATH DEP_DOCDIR ${INSTALL_DOCDIR}
                ${${PREFIX}_DOXYGENDOCDIR})
 
           set(DOXYGEN_TAGFILES_FROM_DEPENDENCIES


### PR DESCRIPTION
_PKG_CONFIG_DOXYGENDOCDIR contained a non-existing path

The previous solution was producing an error of the form:
```bash
-- Doxygen rendering: using MathJax backend
CMake Error at cmake/doxygen.cmake:686 (file):
  file RELATIVE_PATH must be passed a full path to the directory:
  ${pcfiledir}/../../share/doc/proxnlp/doxygen-html
Call Stack (most recent call first):
  cmake/base.cmake:319 (_setup_project_documentation_finalize)
  cmake/base.cmake:210 (setup_project_finalize)
  CMakeLists.txt:9223372036854775807 (SETUP_PROJECT_FINALIZE_HOOK)
```