### PR TITLE
fix ENV syntax for set_default_cmake_build_type

### DIFF
--- a/base.cmake
+++ b/base.cmake
@@ -394,7 +394,7 @@ macro(SET_DEFAULT_CMAKE_BUILD_TYPE build_type)
 
   if(NOT CMAKE_BUILD_TYPE
      AND NOT CMAKE_CONFIGURATION_TYPES
-     AND NOT $ENV{CMAKE_BUILD_TYPE})
+     AND NOT DEFINED $ENV{CMAKE_BUILD_TYPE})
     set(CMAKE_BUILD_TYPE
         ${build_type}
         CACHE STRING "Choose the build type value." FORCE)


### PR DESCRIPTION
ref. https://cmake.org/cmake/help/latest/variable/ENV.html:

> To test whether an environment variable is defined, use the signature
> `if(DEFINED ENV{<name>})` of the `if()` command.