### PR TITLE
python: include python-helpers

### DIFF
--- a/python.cmake
+++ b/python.cmake
@@ -518,3 +518,5 @@ macro(FIND_NUMPY)
     message(STATUS "  NUMPY_VERSION=${NUMPY_VERSION}")
   endif()
 endmacro()
+
+include(${CMAKE_CURRENT_LIST_DIR}/python-helpers.cmake)


### PR DESCRIPTION
#608 moved some things from `python.cmake` to `python-helpers.cmake`.

As a result, projects updating their submodule are now broken with eg.
```
CMake Error at python/CMakeLists.txt:13 (python_install_on_site):
  Unknown CMake command "python_install_on_site".
```

Here is a quick fix, unless I misunderstood something.