### PR TITLE
Update PATH when running generate_stubs on Windows

### DIFF
--- a/stubgen/CMakeLists.txt.in
+++ b/stubgen/CMakeLists.txt.in
@@ -4,7 +4,7 @@ project(stubgen NONE)
 
 include(ExternalProject)
 ExternalProject_Add(stubgen
-  GIT_REPOSITORY    https://github.com/jorisv/pybind11-stubgen.git
+  GIT_REPOSITORY    https://github.com/jcarpent/pybind11-stubgen.git
   GIT_TAG           "${GIT_TAG}"
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/stubgen/src"
   BINARY_DIR        ""

--- a/stubs.cmake
+++ b/stubs.cmake
@@ -26,7 +26,7 @@ set(CURRENT_FILE_PATH
 #
 macro(LOAD_STUBGEN)
   # Handle optional argument
-  set(GIT_TAG "topic/add_dll_directory")
+  set(GIT_TAG "master")
   set(extra_macro_args ${ARGN})
   list(LENGTH extra_macro_args num_extra_args)
   if(${num_extra_args} GREATER 0)


### PR DESCRIPTION
`generate_stubs` need to load an uninstalled Python binding. 
This can be an issue when the Python binding have internal dependencies on Windows.
This PR modify the PATH to allow Python to find those internal dependencies.

On Linux and Mac, this is not an issue thanks to the RPATH.
