### PR TITLE
Properly enforce (when asked) value of CMAKE_CXX_STANDARD when not set but C++ compiler reports right standard

### DIFF
--- a/cxx-standard.cmake
+++ b/cxx-standard.cmake
@@ -147,6 +147,11 @@ macro(CHECK_MINIMAL_CXX_STANDARD STANDARD)
         STATUS
           "C++ standard sufficient: Minimal required ${_MINIMAL_CXX_STANDARD}, currently defined: ${_CURRENT_STANDARD}"
       )
+      # current C++ standard was not set in CMake but we enforce it
+      if(NOT DEFINED CMAKE_CXX_STANDARD AND (ENFORCE_MINIMAL_CXX_STANDARD OR MINIMAL_CXX_STANDARD_ENFORCE))
+        message(STATUS "CMAKE_CXX_STANDARD was not set: automatically set to currently defined standard ${_CURRENT_STANDARD}")
+        set(CMAKE_CXX_STANDARD ${_CURRENT_STANDARD})
+      endif()
     endif() # requested minimum is higher than the currently selected
   endif()
 endmacro()

--- a/cxx-standard.cmake
+++ b/cxx-standard.cmake
@@ -148,8 +148,12 @@ macro(CHECK_MINIMAL_CXX_STANDARD STANDARD)
           "C++ standard sufficient: Minimal required ${_MINIMAL_CXX_STANDARD}, currently defined: ${_CURRENT_STANDARD}"
       )
       # current C++ standard was not set in CMake but we enforce it
-      if(NOT DEFINED CMAKE_CXX_STANDARD AND (ENFORCE_MINIMAL_CXX_STANDARD OR MINIMAL_CXX_STANDARD_ENFORCE))
-        message(STATUS "CMAKE_CXX_STANDARD was not set: automatically set to currently defined standard ${_CURRENT_STANDARD}")
+      if(NOT DEFINED CMAKE_CXX_STANDARD AND (ENFORCE_MINIMAL_CXX_STANDARD
+                                             OR MINIMAL_CXX_STANDARD_ENFORCE))
+        message(
+          STATUS
+            "CMAKE_CXX_STANDARD was not set: automatically set to currently defined standard ${_CURRENT_STANDARD}"
+        )
         set(CMAKE_CXX_STANDARD ${_CURRENT_STANDARD})
       endif()
     endif() # requested minimum is higher than the currently selected


### PR DESCRIPTION
Hi,

This PR fixes a corner case where:
- the variable `CMAKE_CXX_STANDARD` is not set
- the user calls the macro `CHECK_MINIMAL_CXX_STANDARD` with the `ENFORCE` option
- the compiler reports through the `__cplusplus` define that the compiler mode satisfies the C++ standard

Right now, the macro would print the line `C++ standard sufficient: Minimal required ..., currently defined ...`, which only corresponds to what it found regarding the compiler, but leaves `CMAKE_CXX_STANDARD` undefined even when ENFORCE is given.

The change in this PR ensures that, in this corner case, the macro call with the ENFORCE option sets `CMAKE_CXX_STANDARD`  to the detected compiler C++ standard.  
This is useful because the library developer might want to create CMake compile definitions, targets, etc. by checking for `CMAKE_CXX_STANDARD` - before, the macro would report that the compiler standard is sufficient but the rest of the CMake listfile would not behave like it is the case.

I discussed this with @jorisv who checked the diff in this PR and we both think this is a sensible change.