### PR TITLE
bump various cmake_minimum_required

### DIFF
--- a/gtest/CMakeLists.txt.in
+++ b/gtest/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 project(gtest NONE)
 

--- a/stubgen/CMakeLists.txt.in
+++ b/stubgen/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 project(stubgen NONE)
 


### PR DESCRIPTION
Happy new year :)

This is to silence in eg. stubgen:

> CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
>   Compatibility with CMake < 3.5 will be removed from a future version of
>   CMake.
>
>   Update the VERSION argument <min> value or use a ...<max> suffix to tell
>   CMake that the project does not need compatibility with older versions.