### PR TITLE
Add CXX_FLAGS_BY_COMPILER_FRONTEND function

### DIFF
--- a/compiler.cmake
+++ b/compiler.cmake
@@ -72,7 +72,8 @@ endmacro(_SETUP_PROJECT_WARNINGS)
 .. command:: CXX_FLAGS_BY_COMPILER_FRONTEND(<CLANG [<flags1>...]>
                                             <GCC   [<flags1>...]>
                                             <MSVC  [<flags1>...]>
-                                            OUTPUT flags)
+                                            OUTPUT flags
+                                            <FILTER>)
 
 Detect the compiler frontend (the command line interface) and output the
 corresponding ``CXX_FLAGS``.
@@ -87,6 +88,8 @@ Lst of flags for MSVC compiler frontend (MSVC, ClangCl)
 Detected compiler frontend flags are then outputed in the ``OUTPUT``
 parameter.
 
+Optional ``FILTER`` parameter filter outputed flags with check_cxx_compiler_flag.
+
 Example
 ^^^^^^^
 
@@ -95,11 +98,12 @@ Example
     GNU -Wno-conversion -Wno-comment
     CLANG -Wno-conversion -Wno-comment -Wno-self-assign-overloaded
     MSVC  "/bigobj"
-    OUTPUT COMPLIE_OPTIONS)
+    OUTPUT COMPLIE_OPTIONS
+    FILTER)
 #]=======================================================================]
 
 function(CXX_FLAGS_BY_COMPILER_FRONTEND)
-  set(options)
+  set(options FILTER)
   set(oneValueArgs OUTPUT)
   set(multiValueArgs GNU CLANG MSVC)
   cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
@@ -122,7 +126,18 @@ function(CXX_FLAGS_BY_COMPILER_FRONTEND)
                     "No flags outputed")
   endif()
 
+  if(ARGS_FILTER)
+    foreach(FLAG ${FLAGS})
+      check_cxx_compiler_flag(${FLAG} res_${FLAG})
+      if(${res_${FLAG}})
+        list(APPEND FILTERED_FLAGS ${FLAG})
+      endif()
+    endforeach()
+  else()
+    set(FILTERED_FLAGS ${FLAGS})
+  endif()
+
   set(${ARGS_OUTPUT}
-      ${FLAGS}
+      ${FILTERED_FLAGS}
       PARENT_SCOPE)
 endfunction()

--- a/compiler.cmake
+++ b/compiler.cmake
@@ -90,6 +90,9 @@ parameter.
 
 Optional ``FILTER`` parameter filter outputed flags with check_cxx_compiler_flag.
 
+.. warning:: When ``FILTER`` option is activated, definition should by passed with
+-D prefix to be valid compiler parameter.
+
 Example
 ^^^^^^^
 

--- a/compiler.cmake
+++ b/compiler.cmake
@@ -112,8 +112,8 @@ function(CXX_FLAGS_BY_COMPILER_FRONTEND)
                         ${ARGN})
 
   # Before CMake 3.14, the CMAKE_CXX_COMPILER_FRONTEND_VARIANT doesn't exists.
-  # Before CMake 3.26, the CMAKE_CXX_COMPILER_FRONTEND_VARIANT doesn't exists
-  # when CMAKE_CXX_COMPILER_ID is set to GNU, MSVC or AppleClang
+  # Before CMake 3.26, when CMAKE_CXX_COMPILER_ID is set to GNU, MSVC or
+  # AppleClang, CMAKE_CXX_COMPILER_FRONTEND_VARIANT doesn't exists either
   if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT)
     if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
       set(FLAGS ${ARGS_GNU})

--- a/compiler.cmake
+++ b/compiler.cmake
@@ -69,8 +69,7 @@ macro(_SETUP_PROJECT_WARNINGS)
 endmacro(_SETUP_PROJECT_WARNINGS)
 
 #[=======================================================================[.rst:
-.. command:: CXX_FLAGS_BY_COMPILER_FRONTEND(<CLANG [<flags1>...]>
-                                            <GCC   [<flags1>...]>
+.. command:: CXX_FLAGS_BY_COMPILER_FRONTEND(<GCC   [<flags1>...]>
                                             <MSVC  [<flags1>...]>
                                             OUTPUT flags
                                             <FILTER>)
@@ -81,9 +80,8 @@ corresponding ``CXX_FLAGS``.
 The following arguments allow to specify ``CXX_FLAGS`` for a compiler
 frontend:
 
-:param CLANG: List of flags for Clang compiler frontend (Clang, AppleClang)
-:param GNU: List of flags for GNU compiler frontend (Gcc, G++) :param MSVC:
-Lst of flags for MSVC compiler frontend (MSVC, ClangCl)
+:param GNU: List of flags for GNU compiler frontend (Gcc, G++)
+:param MSVC: List of flags for MSVC compiler frontend (MSVC, ClangCl)
 
 Detected compiler frontend flags are then outputed in the ``OUTPUT``
 parameter.
@@ -98,8 +96,7 @@ Example
 
 .. code-block:: cmake
   CXX_FLAGS_BY_COMPILER_FRONTEND(
-    GNU -Wno-conversion -Wno-comment
-    CLANG -Wno-conversion -Wno-comment -Wno-self-assign-overloaded
+    GNU -Wno-conversion -Wno-comment -Wno-self-assign-overloaded
     MSVC  "/bigobj"
     OUTPUT COMPLIE_OPTIONS
     FILTER)
@@ -108,25 +105,36 @@ Example
 function(CXX_FLAGS_BY_COMPILER_FRONTEND)
   set(options FILTER)
   set(oneValueArgs OUTPUT)
-  set(multiValueArgs GNU CLANG MSVC)
+  set(multiValueArgs GNU MSVC)
   cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
                         ${ARGN})
 
-  # We should use CMAKE_CXX_COMPILER_FRONTEND_VARIANT, but it's introduced in
-  # CMake 3.14
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES
-                                               "MSVC")
-    set(FLAGS ${ARGS_MSVC})
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(FLAGS ${ARGS_MSVC})
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(FLAGS ${ARGS_GNU})
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(FLAGS ${ARGS_CLANG})
+  # Before CMake 3.14, the CMAKE_CXX_COMPILER_FRONTEND_VARIANT doesn't exists.
+  # Before CMake 3.26, the CMAKE_CXX_COMPILER_FRONTEND_VARIANT doesn't exists
+  # when CMAKE_CXX_COMPILER_ID is set to GNU, MSVC or AppleClang
+  if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT)
+    if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
+      set(FLAGS ${ARGS_GNU})
+    elseif(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+      set(FLAGS ${ARGS_MSVC})
+    else()
+      message(WARNING "Unknown compiler frontend for '${CMAKE_CXX_COMPILER_ID}' "
+                      "with frontend '${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}'\n"
+                      "No flags outputed")
+    endif()
   else()
-    message(WARNING "Unknown compiler frontend for '${CMAKE_CXX_COMPILER_ID}' "
-                    "with simulated ID '${CMAKE_CXX_SIMULATED_ID}'\n"
-                    "No flags outputed")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES
+                                                 "MSVC")
+      set(FLAGS ${ARGS_MSVC})
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      set(FLAGS ${ARGS_MSVC})
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+      set(FLAGS ${ARGS_GNU})
+    else()
+      message(WARNING "Unknown compiler frontend for '${CMAKE_CXX_COMPILER_ID}' "
+                      "with simulated ID '${CMAKE_CXX_SIMULATED_ID}'\n"
+                      "No flags outputed")
+    endif()
   endif()
 
   if(ARGS_FILTER)

--- a/compiler.cmake
+++ b/compiler.cmake
@@ -20,15 +20,15 @@ macro(_SETUP_PROJECT_WARNINGS)
   # support it but CMake doest not check for the flag acceptance correctly.
 
   set(GNU_FLAGS
-        -pedantic
-        -Wno-long-long
-        -Wall
-        -Wextra
-        -Wcast-align
-        -Wcast-qual
-        -Wformat
-        -Wwrite-strings
-        -Wconversion)
+      -pedantic
+      -Wno-long-long
+      -Wall
+      -Wextra
+      -Wcast-align
+      -Wcast-qual
+      -Wformat
+      -Wwrite-strings
+      -Wconversion)
   if(NOT DEFINED CXX_DISABLE_WERROR)
     list(APPEND GNU_FLAGS -Werror)
   endif(NOT DEFINED CXX_DISABLE_WERROR)
@@ -37,28 +37,31 @@ macro(_SETUP_PROJECT_WARNINGS)
   # which is way too verbose The default levels (W3/W4) are enough The next
   # macro remove warnings on deprecations due to stl.
   set(MSVC_FLAGS
-    -D_SCL_SECURE_NO_WARNINGS
-    -D_CRT_SECURE_NO_WARNINGS
-    -D_CRT_SECURE_NO_DEPRECATE
-    # -- The following warnings are removed to highlight the output C4101 The
-    # local variable is never used removed since happens frequently in headers.
-    /wd4101
-    # C4250 'class1' : inherits 'class2::member' via dominance
-    /wd4250
-    # C4251 class 'type' needs to have dll-interface to be used by clients of
-    # class 'type2' ~ in practice, raised by the classes that have non-dll
-    # attribute (such as std::vector)
-    /wd4251
-    # C4275 non - DLL-interface used as base for DLL-interface
-    /wd4275
-    # C4355 "this" used in base member initializer list
-    /wd4355
-    )
+      -D_SCL_SECURE_NO_WARNINGS
+      -D_CRT_SECURE_NO_WARNINGS
+      -D_CRT_SECURE_NO_DEPRECATE
+      # -- The following warnings are removed to highlight the output C4101 The
+      # local variable is never used removed since happens frequently in
+      # headers.
+      /wd4101
+      # C4250 'class1' : inherits 'class2::member' via dominance
+      /wd4250
+      # C4251 class 'type' needs to have dll-interface to be used by clients of
+      # class 'type2' ~ in practice, raised by the classes that have non-dll
+      # attribute (such as std::vector)
+      /wd4251
+      # C4275 non - DLL-interface used as base for DLL-interface
+      /wd4275
+      # C4355 "this" used in base member initializer list
+      /wd4355)
 
-  CXX_FLAGS_BY_COMPILER_FRONTEND(
-    GNU ${GNU_FLAGS}
-    MSVC ${MSVC_FLAGS}
-    OUTPUT WARNING_CXX_FLAGS_LIST
+  cxx_flags_by_compiler_frontend(
+    GNU
+    ${GNU_FLAGS}
+    MSVC
+    ${MSVC_FLAGS}
+    OUTPUT
+    WARNING_CXX_FLAGS_LIST
     FILTER)
   string(REPLACE ";" " " WARNING_CXX_FLAGS "${WARNING_CXX_FLAGS_LIST}")
 
@@ -117,9 +120,10 @@ function(CXX_FLAGS_BY_COMPILER_FRONTEND)
     elseif(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
       set(FLAGS ${ARGS_MSVC})
     else()
-      message(WARNING "Unknown compiler frontend for '${CMAKE_CXX_COMPILER_ID}' "
-                      "with frontend '${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}'\n"
-                      "No flags outputed")
+      message(
+        WARNING "Unknown compiler frontend for '${CMAKE_CXX_COMPILER_ID}' "
+                "with frontend '${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}'\n"
+                "No flags outputed")
     endif()
   else()
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES
@@ -130,9 +134,10 @@ function(CXX_FLAGS_BY_COMPILER_FRONTEND)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
       set(FLAGS ${ARGS_GNU})
     else()
-      message(WARNING "Unknown compiler frontend for '${CMAKE_CXX_COMPILER_ID}' "
-                      "with simulated ID '${CMAKE_CXX_SIMULATED_ID}'\n"
-                      "No flags outputed")
+      message(
+        WARNING "Unknown compiler frontend for '${CMAKE_CXX_COMPILER_ID}' "
+                "with simulated ID '${CMAKE_CXX_SIMULATED_ID}'\n"
+                "No flags outputed")
     endif()
   endif()
 

--- a/compiler.cmake
+++ b/compiler.cmake
@@ -67,3 +67,62 @@ macro(_SETUP_PROJECT_WARNINGS)
 
   list(APPEND LOGGING_WATCHED_VARIABLES WARNING_CXX_FLAGS)
 endmacro(_SETUP_PROJECT_WARNINGS)
+
+#[=======================================================================[.rst:
+.. command:: CXX_FLAGS_BY_COMPILER_FRONTEND(<CLANG [<flags1>...]>
+                                            <GCC   [<flags1>...]>
+                                            <MSVC  [<flags1>...]>
+                                            OUTPUT flags)
+
+Detect the compiler frontend (the command line interface) and output the
+corresponding ``CXX_FLAGS``.
+
+The following arguments allow to specify ``CXX_FLAGS`` for a compiler
+frontend:
+
+:param CLANG: List of flags for Clang compiler frontend (Clang, AppleClang)
+:param GNU: List of flags for GNU compiler frontend (Gcc, G++) :param MSVC:
+Lst of flags for MSVC compiler frontend (MSVC, ClangCl)
+
+Detected compiler frontend flags are then outputed in the ``OUTPUT``
+parameter.
+
+Example
+^^^^^^^
+
+.. code-block:: cmake
+  CXX_FLAGS_BY_COMPILER_FRONTEND(
+    GNU -Wno-conversion -Wno-comment
+    CLANG -Wno-conversion -Wno-comment -Wno-self-assign-overloaded
+    MSVC  "/bigobj"
+    OUTPUT COMPLIE_OPTIONS)
+#]=======================================================================]
+
+function(CXX_FLAGS_BY_COMPILER_FRONTEND)
+  set(options)
+  set(oneValueArgs OUTPUT)
+  set(multiValueArgs GNU CLANG MSVC)
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
+
+  # We should use CMAKE_CXX_COMPILER_FRONTEND_VARIANT, but it's introduced in
+  # CMake 3.14
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES
+                                               "MSVC")
+    set(FLAGS ${ARGS_MSVC})
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set(FLAGS ${ARGS_MSVC})
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(FLAGS ${ARGS_GNU})
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(FLAGS ${ARGS_CLANG})
+  else()
+    message(WARNING "Unknown compiler frontend for '${CMAKE_CXX_COMPILER_ID}' "
+                    "with simulated ID '${CMAKE_CXX_SIMULATED_ID}'\n"
+                    "No flags outputed")
+  endif()
+
+  set(${ARGS_OUTPUT}
+      ${FLAGS}
+      PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
This function allow to choose different compiler options or definitions based on the compiler frontend