### PR TITLE
[doxygen] Remove duplicate entries in TAGFILES variable.

### DIFF
--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -622,9 +622,11 @@ function(REMOVE_DUPLICATES ARG_STR OUTPUT)
   set(ARG_LIST ${ARG_STR})
   separate_arguments(ARG_LIST)
   list(REMOVE_DUPLICATES ARG_LIST)
-  string (REGEX REPLACE "([^\\]|^);" "\\1 " _TMP_STR "${ARG_LIST}")
-  string (REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") #fixes escaping
-  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
+  string(REGEX REPLACE "([^\\]|^);" "\\1 " _TMP_STR "${ARG_LIST}")
+  string(REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") # fixes escaping
+  set(${OUTPUT}
+      "${_TMP_STR}"
+      PARENT_SCOPE)
 endfunction()
 
 # _DOXYTAG_ENTRIES_FROM_CMAKE_DEPENDENCIES
@@ -706,10 +708,9 @@ macro(_SETUP_PROJECT_DOCUMENTATION_FINALIZE)
         endif()
       endforeach()
       _doxytag_entries_from_cmake_dependencies(
-        "${_PACKAGE_CONFIG_DEPENDENCIES_PROJECTS}"
-        _TAGFILES_FROM_DEPENDENCIES)
+        "${_PACKAGE_CONFIG_DEPENDENCIES_PROJECTS}" _TAGFILES_FROM_DEPENDENCIES)
       remove_duplicates(${_TAGFILES_FROM_DEPENDENCIES}
-        DOXYGEN_TAGFILES_FROM_DEPENDENCIES)
+                        DOXYGEN_TAGFILES_FROM_DEPENDENCIES)
     endif()
     _set_if_undefined(DOXYGEN_TAGFILES "${DOXYGEN_TAGFILES_FROM_DEPENDENCIES}")
 

--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -614,6 +614,19 @@ macro(_SETUP_PROJECT_DOCUMENTATION)
   endif(NOT DOXYGEN_FOUND)
 endmacro(_SETUP_PROJECT_DOCUMENTATION)
 
+# REMOVE_DUPLICATES
+# -----------------
+#
+# Remove duplicate values from a space separated list
+function(REMOVE_DUPLICATES ARG_STR OUTPUT)
+  set(ARG_LIST ${ARG_STR})
+  separate_arguments(ARG_LIST)
+  list(REMOVE_DUPLICATES ARG_LIST)
+  string (REGEX REPLACE "([^\\]|^);" "\\1 " _TMP_STR "${ARG_LIST}")
+  string (REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") #fixes escaping
+  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
+endfunction()
+
 # _DOXYTAG_ENTRIES_FROM_CMAKE_DEPENDENCIES
 # ----------------------------------------
 #
@@ -687,13 +700,15 @@ macro(_SETUP_PROJECT_DOCUMENTATION_FINALIZE)
           file(RELATIVE_PATH DEP_DOCDIR ${INSTALL_DOCDIR}
                ${${PREFIX}_DOXYGENDOCDIR})
 
-          set(DOXYGEN_TAGFILES_FROM_DEPENDENCIES
-              "${DOXYGEN_TAGFILES_FROM_DEPENDENCIES} \"${${PREFIX}_DOXYGENDOCDIR}/${LIBRARY_NAME}.doxytag = ${DEP_DOCDIR}\""
+          set(_TAGFILES_FROM_DEPENDENCIES
+              "${_TAGFILES_FROM_DEPENDENCIES} \"${${PREFIX}_DOXYGENDOCDIR}/${LIBRARY_NAME}.doxytag = ${DEP_DOCDIR}\""
           )
         endif()
       endforeach()
       _doxytag_entries_from_cmake_dependencies(
         "${_PACKAGE_CONFIG_DEPENDENCIES_PROJECTS}"
+        _TAGFILES_FROM_DEPENDENCIES)
+      remove_duplicates(${_TAGFILES_FROM_DEPENDENCIES}
         DOXYGEN_TAGFILES_FROM_DEPENDENCIES)
     endif()
     _set_if_undefined(DOXYGEN_TAGFILES "${DOXYGEN_TAGFILES_FROM_DEPENDENCIES}")


### PR DESCRIPTION
Generating TAGFILES recursively results in low level dependencies to be duplicated many times in the variable.
This makes doxygen run for hours when compiling hpp-doc for example.

This PR removes duplicate entries.