### PR TITLE
Use ${CMAKE_COMMAND} instead of @CMAKE_COMMAND@ in generated scripts

### DIFF
--- a/cmake_reinstall.cmake.in
+++ b/cmake_reinstall.cmake.in
@@ -13,6 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 if(EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
-  execute_process(COMMAND "@CMAKE_COMMAND@" --build "@PROJECT_BINARY_DIR@" --target uninstall --config $<CONFIGURATION>)
+  execute_process(COMMAND ${CMAKE_COMMAND} --build "@PROJECT_BINARY_DIR@" --target uninstall --config $<CONFIGURATION>)
 endif()
-execute_process(COMMAND "@CMAKE_COMMAND@" --build "@PROJECT_BINARY_DIR@" --target install --config $<CONFIGURATION>)
+execute_process(COMMAND ${CMAKE_COMMAND} --build "@PROJECT_BINARY_DIR@" --target install --config $<CONFIGURATION>)

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -22,7 +22,7 @@ MESSAGE(STATUS "catkin path: @CMAKE_INSTALL_PREFIX@/.catkin")
 IF(EXISTS "@CMAKE_INSTALL_PREFIX@/.catkin" AND PACKAGE_CREATES_DOT_CATKIN)
   MESSAGE(STATUS "Try to remove @CMAKE_INSTALL_PREFIX@/.catkin")
   EXECUTE_PROCESS(
-      COMMAND @CMAKE_COMMAND@ -E remove "@CMAKE_INSTALL_PREFIX@/.catkin"
+      COMMAND ${CMAKE_COMMAND} -E remove "@CMAKE_INSTALL_PREFIX@/.catkin"
       RESULT_VARIABLE rm_resval
       OUTPUT_VARIABLE rm_out
       ERROR_VARIABLE rm_err
@@ -40,7 +40,7 @@ FOREACH(file ${files})
   MESSAGE(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
   IF(EXISTS "$ENV{DESTDIR}${file}")
     EXECUTE_PROCESS(
-      COMMAND @CMAKE_COMMAND@ -E remove "$ENV{DESTDIR}${file}"
+      COMMAND ${CMAKE_COMMAND} -E remove "$ENV{DESTDIR}${file}"
       RESULT_VARIABLE rm_resval
       OUTPUT_VARIABLE rm_out
       )
@@ -54,7 +54,7 @@ FOREACH(file ${files})
       IF(EXISTS "$ENV{DESTDIR}${pycfile}")
         MESSAGE(STATUS "Uninstalling \"$ENV{DESTDIR}${pycfile}\"")
         EXECUTE_PROCESS(
-          COMMAND @CMAKE_COMMAND@ -E remove "$ENV{DESTDIR}${pycfile}"
+          COMMAND ${CMAKE_COMMAND} -E remove "$ENV{DESTDIR}${pycfile}"
           RESULT_VARIABLE rm_resval
           OUTPUT_VARIABLE rm_out
           )
@@ -70,7 +70,7 @@ FOREACH(file ${files})
     # If file is a broken symbolic link, EXISTS returns false.
     # Workaround this bug by attempting to remove the file anyway.
     EXECUTE_PROCESS(
-      COMMAND @CMAKE_COMMAND@ -E remove "$ENV{DESTDIR}${file}"
+      COMMAND ${CMAKE_COMMAND} -E remove "$ENV{DESTDIR}${file}"
       RESULT_VARIABLE rm_resval
       OUTPUT_VARIABLE rm_out
       ERROR_QUIET
@@ -78,7 +78,7 @@ FOREACH(file ${files})
   ENDIF(EXISTS "$ENV{DESTDIR}${file}")
 ENDFOREACH(file)
 EXECUTE_PROCESS(
-  COMMAND "@CMAKE_COMMAND@" -E remove "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt"
+  COMMAND ${CMAKE_COMMAND} -E remove "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt"
   RESULT_VARIABLE rm_resval
   OUTPUT_VARIABLE rm_out
   ERROR_QUIET

--- a/uninstall.cmake
+++ b/uninstall.cmake
@@ -40,7 +40,7 @@ macro(_SETUP_PROJECT_UNINSTALL)
   # remember what we install ?!
   configure_file(
     "${CMAKE_CURRENT_LIST_DIR}/cmake_uninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake" IMMEDIATE @ONLY)
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake" @ONLY)
 
   add_custom_target(
     uninstall
@@ -48,8 +48,9 @@ macro(_SETUP_PROJECT_UNINSTALL)
     -DPACKAGE_CREATES_DOT_CATKIN=${PACKAGE_CREATES_DOT_CATKIN} -P
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
 
-  configure_file("${CMAKE_CURRENT_LIST_DIR}/cmake_reinstall.cmake.in"
-                 "${PROJECT_BINARY_DIR}/cmake/cmake_reinstall.cmake.configured")
+  configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/cmake_reinstall.cmake.in"
+    "${PROJECT_BINARY_DIR}/cmake/cmake_reinstall.cmake.configured" @ONLY)
   if(DEFINED CMAKE_BUILD_TYPE)
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cmake/${CMAKE_BUILD_TYPE}")
   else(DEFINED CMAKE_BUILD_TYPE)


### PR DESCRIPTION
I encountered some issues on a computer where CMake is installed with a space inserted. using `@CMAKE_COMMAND@` instead of  `"@CMAKE_COMMAND@"` would create some problems. However, there's not much point in using `@CMAKE_COMMAND@` in the first place so I have replaced all usage with `${CMAKE_COMMAND}` which is correctly handled in the `execute_process` calls