### PR TITLE
doxygen: fix remove_duplicate

### DIFF
--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -709,8 +709,10 @@ macro(_SETUP_PROJECT_DOCUMENTATION_FINALIZE)
       endforeach()
       _doxytag_entries_from_cmake_dependencies(
         "${_PACKAGE_CONFIG_DEPENDENCIES_PROJECTS}" _TAGFILES_FROM_DEPENDENCIES)
-      remove_duplicates(${_TAGFILES_FROM_DEPENDENCIES}
-                        DOXYGEN_TAGFILES_FROM_DEPENDENCIES)
+      if(_TAGFILES_FROM_DEPENDENCIES)
+        remove_duplicates(${_TAGFILES_FROM_DEPENDENCIES}
+                          DOXYGEN_TAGFILES_FROM_DEPENDENCIES)
+      endif()
     endif()
     _set_if_undefined(DOXYGEN_TAGFILES "${DOXYGEN_TAGFILES_FROM_DEPENDENCIES}")
 


### PR DESCRIPTION
Following #669, remove_duplicate might be called on en empty list, resulting with:
```cmake
CMake Error at cmake/doxygen.cmake:712 (remove_duplicates):
  remove_duplicates Function invoked with incorrect arguments for function
  named: REMOVE_DUPLICATES
Call Stack (most recent call first):
  cmake/base.cmake:328 (_setup_project_documentation_finalize)
  cmake/base.cmake:228 (setup_project_finalize)
  CMakeLists.txt:9223372036854775807 (SETUP_PROJECT_FINALIZE_HOOK)