### PR TITLE
find-external coin-utils: include coin subdir

### DIFF
--- a/find-external/CoinUtils/FindCoinUtils.cmake
+++ b/find-external/CoinUtils/FindCoinUtils.cmake
@@ -44,7 +44,7 @@ if(CoinUtils_FOUND AND NOT TARGET CoinUtils::CoinUtils)
   add_library(CoinUtils::CoinUtils SHARED IMPORTED)
   set_target_properties(
     CoinUtils::CoinUtils PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                    "${CoinUtils_INCLUDE_DIR}")
+                                    "${CoinUtils_INCLUDE_DIR};${CoinUtils_INCLUDE_DIR}/coin")
   set_target_properties(
     CoinUtils::CoinUtils PROPERTIES IMPORTED_LOCATION_RELEASE
                                     "${CoinUtils_LIBRARY}")

--- a/find-external/CoinUtils/FindCoinUtils.cmake
+++ b/find-external/CoinUtils/FindCoinUtils.cmake
@@ -43,8 +43,9 @@ mark_as_advanced(CoinUtils_INCLUDE_DIR CoinUtils_LIBRARY)
 if(CoinUtils_FOUND AND NOT TARGET CoinUtils::CoinUtils)
   add_library(CoinUtils::CoinUtils SHARED IMPORTED)
   set_target_properties(
-    CoinUtils::CoinUtils PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                    "${CoinUtils_INCLUDE_DIR};${CoinUtils_INCLUDE_DIR}/coin")
+    CoinUtils::CoinUtils
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+               "${CoinUtils_INCLUDE_DIR};${CoinUtils_INCLUDE_DIR}/coin")
   set_target_properties(
     CoinUtils::CoinUtils PROPERTIES IMPORTED_LOCATION_RELEASE
                                     "${CoinUtils_LIBRARY}")


### PR DESCRIPTION
Hi,

This fix uses of clp when clp and coin-utils are not installed in the same prefix, because clp try to include "CoinPragma.hpp" from coin-utils while coin-utils export include/ as includedir and provide include/coin/CoinPragma.hpp.