### PR TITLE
Manage suppresion file when calling valgrind

### DIFF
--- a/memorycheck_unit_test.cmake.in
+++ b/memorycheck_unit_test.cmake.in
@@ -1,32 +1,39 @@
 # Copyright (C) 2023 LAAS-CNRS, JRL AIST-CNRS, INRIA.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-SET(PYTHON_EXECUTABLE @PYTHON_EXECUTABLE@)
-SET(MEMORYCHECK_COMMAND @MEMORYCHECK_COMMAND@)
-SET(PYTHON_TEST_SCRIPT @PYTHON_TEST_SCRIPT@)
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+set(PYTHON_EXECUTABLE @PYTHON_EXECUTABLE@)
+set(MEMORYCHECK_COMMAND @MEMORYCHECK_COMMAND@)
+set(PYTHON_TEST_SCRIPT @PYTHON_TEST_SCRIPT@)
+set(VALGRIND_SUPP_FILE @VALGRIND_SUPP_FILE@)
 
-execute_process(COMMAND
-  ${MEMORYCHECK_COMMAND} -- ${PYTHON_EXECUTABLE} ${PYTHON_TEST_SCRIPT}
-  ERROR_VARIABLE MEMORYCHECK_OUTPUT)
+if(VALGRIND_SUPP_FILE)
+  set(SUPP_ARGS --suppressions=${VALGRIND_SUPP_FILE})
+endif()
+
+execute_process(
+  COMMAND ${MEMORYCHECK_COMMAND} ${SUPP_ARGS} -- ${PYTHON_EXECUTABLE}
+          ${PYTHON_TEST_SCRIPT} ERROR_VARIABLE MEMORYCHECK_OUTPUT)
 
 # Check if there is some memory leaks
-string(FIND "${MEMORYCHECK_OUTPUT}" "definitely lost: 0 bytes in 0 blocks" DEFINITELY_LOST)
-string(FIND "${MEMORYCHECK_OUTPUT}" "indirectly lost: 0 bytes in 0 blocks" INDIRECTLY_LOST)
+string(FIND "${MEMORYCHECK_OUTPUT}" "definitely lost: 0 bytes in 0 blocks"
+            DEFINITELY_LOST)
+string(FIND "${MEMORYCHECK_OUTPUT}" "indirectly lost: 0 bytes in 0 blocks"
+            INDIRECTLY_LOST)
 
 if(${DEFINITELY_LOST} GREATER -1 AND ${INDIRECTLY_LOST} GREATER -1)
   message(STATUS "${PYTHON_TEST_SCRIPT} is not leaking memory")
 else()
   message(FATAL_ERROR "Output: ${MEMORYCHECK_OUTPUT}\n"
-    "${PYTHON_TEST_SCRIPT} is leaking memory\n")
+                      "${PYTHON_TEST_SCRIPT} is leaking memory\n")
 endif()


### PR DESCRIPTION
- Add a new function (`ADD_PYTHON_MEMORYCHECK_UNIT_TEST_V2`) to extend more easily the function API
- Allow to give a suppresion file to valgrind