### PR TITLE
Fix FindMPFR and FindGMP on Windows

### DIFF
--- a/find-external/GMP/FindGMP.cmake
+++ b/find-external/GMP/FindGMP.cmake
@@ -22,8 +22,15 @@ find_package_handle_standard_args(GMP DEFAULT_MSG GMP_INCLUDES GMP_LIBRARIES)
 if(GMP_FOUND)
   add_library(gmp SHARED IMPORTED)
   set_target_properties(
-    gmp PROPERTIES IMPORTED_LOCATION ${GMP_LIBRARIES}
-                   INTERFACE_INCLUDE_DIRECTORIES "${GMP_INCLUDE_DIR}")
+    gmp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${GMP_INCLUDE_DIR}"
+                   IMPORTED_CONFIGURATIONS "RELEASE")
+  if(WIN32)
+    set_target_properties(gmp PROPERTIES IMPORTED_IMPLIB_RELEASE
+                                         "${GMP_LIBRARIES}")
+  else()
+    set_target_properties(gmp PROPERTIES IMPORTED_LOCATION_RELEASE
+                                         "${GMP_LIBRARIES}")
+  endif()
 endif()
 
 mark_as_advanced(GMP_INCLUDES GMP_LIBRARIES)

--- a/find-external/MPFR/FindMPFR.cmake
+++ b/find-external/MPFR/FindMPFR.cmake
@@ -82,8 +82,15 @@ find_package_handle_standard_args(MPFR DEFAULT_MSG MPFR_INCLUDES MPFR_LIBRARIES
 if(MPFR_FOUND)
   add_library(mpfr SHARED IMPORTED)
   set_target_properties(
-    mpfr PROPERTIES IMPORTED_LOCATION ${MPFR_LIBRARIES}
-                    INTERFACE_INCLUDE_DIRECTORIES "${MPFR_INCLUDE_DIR}")
+    mpfr PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${MPFR_INCLUDE_DIR}"
+                    IMPORTED_CONFIGURATIONS "RELEASE")
+  if(WIN32)
+    set_target_properties(mpfr PROPERTIES IMPORTED_IMPLIB_RELEASE
+                                          "${MPFR_LIBRARIES}")
+  else()
+    set_target_properties(mpfr PROPERTIES IMPORTED_LOCATION_RELEASE
+                                          "${MPFR_LIBRARIES}")
+  endif()
 endif()
 
 # Epilogue


### PR DESCRIPTION
- Use `IMPORTED_IMPLIB` instead of `IMPORTED_LOCATION` on Windows