### PR TITLE
GENERATE_CONFIGURATION_HEADER_V2

### DIFF
--- a/header.cmake
+++ b/header.cmake
@@ -190,8 +190,7 @@ endfunction(GENERATE_CONFIGURATION_HEADER)
 # :param LIBRARY_NAME: CPP symbol prefix, should match the compiled library
 # name.
 #
-# :param EXPORT_SYMBOL: Controls the switch between symbol
-# import/export.
+# :param EXPORT_SYMBOL: Controls the switch between symbol import/export.
 function(GENERATE_CONFIGURATION_HEADER_V2)
   set(options)
   set(oneValueArgs INCLUDE_DIR HEADER_DIR FILENAME LIBRARY_NAME EXPORT_SYMBOL)

--- a/header.cmake
+++ b/header.cmake
@@ -149,44 +149,86 @@ endmacro(_SETUP_PROJECT_HEADER)
 # This macro generates a configuration header. Macro parameters may be used to
 # customize it.
 #
-# HEADER_DIR    : where to generate the header FILENAME      : how should the
-# file named LIBRARY_NAME  : CPP symbol prefix, should match the compiled
-# library name EXPORT_SYMBOl : what symbol controls the switch between symbol
-# import/export
+# * HEADER_DIR    : where to generate the header
+# * FILENAME      : how should the file named
+# * LIBRARY_NAME  : CPP symbol prefix, should match the compiled library name
+# * EXPORT_SYMBOl : what symbol controls the switch between symbol import/export
 function(GENERATE_CONFIGURATION_HEADER HEADER_DIR FILENAME LIBRARY_NAME
          EXPORT_SYMBOL)
+  # cmake-format: off
+  generate_configuration_header_v2(
+    INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include
+    HEADER_DIR ${HEADER_DIR}
+    FILENAME ${FILENAME}
+    LIBRARY_NAME ${LIBRARY_NAME}
+    EXPORT_SYMBOL ${EXPORT_SYMBOL})
+  # cmake-format: on
+endfunction(GENERATE_CONFIGURATION_HEADER)
+
+# ~~~
+# .rst: .. command:: GENERATE_CONFIGURATION_HEADER_V2 (
+#   INCLUDE_DIR <include_dir>
+#   HEADER_DIR <header_dir>
+#   FILENAME <filename>
+#   LIBRARY_NAME <library_name>
+#   EXPORT_SYBMOL <export_symbol>)
+# ~~~
+#
+# This function generates a configuration header at ``<include_dir>/<header_dir>/<filename>``.
+#
+# If INSTALL_GENERATED_HEADERS is ON, the configuration header will be installed in
+# ``${CMAKE_INSTALL_INCLUDEDIR}/<header_dir>``.
+#
+# :param INCLUDE_DIR: Include root directory (absolute).
+#
+# :param HEADER_DIR: Include sub directory.
+#
+# :param FILENAME: Configuration header name.
+#
+# :param LIBRARY_NAME: CPP symbol prefix, should match the compiled library name.
+#
+# :param EXPORT_SYMBOL: What symbol controls the switch between symbol import/export.
+function(GENERATE_CONFIGURATION_HEADER_V2)
+  set(options)
+  set(oneValueArgs INCLUDE_DIR HEADER_DIR FILENAME LIBRARY_NAME EXPORT_SYMBOL)
+  set(multiValueArgs)
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
 
   if(${PROJECT_VERSION_MAJOR} MATCHES UNKNOWN)
-    set(PROJECT_VERSION_MAJOR_CONFIG ${LIBRARY_NAME}_VERSION_UNKNOWN_TAG)
+    set(PROJECT_VERSION_MAJOR_CONFIG ${ARGS_LIBRARY_NAME}_VERSION_UNKNOWN_TAG)
   else()
     set(PROJECT_VERSION_MAJOR_CONFIG ${PROJECT_VERSION_MAJOR})
   endif()
 
   if(${PROJECT_VERSION_MINOR} MATCHES UNKNOWN)
-    set(PROJECT_VERSION_MINOR_CONFIG ${LIBRARY_NAME}_VERSION_UNKNOWN_TAG)
+    set(PROJECT_VERSION_MINOR_CONFIG ${ARGS_LIBRARY_NAME}_VERSION_UNKNOWN_TAG)
   else()
     set(PROJECT_VERSION_MINOR_CONFIG ${PROJECT_VERSION_MINOR})
   endif()
 
   if(${PROJECT_VERSION_PATCH} MATCHES UNKNOWN)
-    set(PROJECT_VERSION_PATCH_CONFIG ${LIBRARY_NAME}_VERSION_UNKNOWN_TAG)
+    set(PROJECT_VERSION_PATCH_CONFIG ${ARGS_LIBRARY_NAME}_VERSION_UNKNOWN_TAG)
   else()
     set(PROJECT_VERSION_PATCH_CONFIG ${PROJECT_VERSION_PATCH})
   endif()
 
+  # Set variables for configure_file command
+  set(EXPORT_SYMBOL ${ARGS_EXPORT_SYMBOL})
+  set(LIBRARY_NAME ${ARGS_LIBRARY_NAME})
+
   # Generate the header.
-  configure_file(
-    ${PROJECT_JRL_CMAKE_MODULE_DIR}/config.hh.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/${FILENAME} @ONLY)
+  configure_file(${PROJECT_JRL_CMAKE_MODULE_DIR}/config.hh.cmake
+                 ${ARGS_INCLUDE_DIR}/${ARGS_HEADER_DIR}/${ARGS_FILENAME} @ONLY)
 
   # Install it if requested.
   if(INSTALL_GENERATED_HEADERS)
     install(
-      FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/${FILENAME}
-      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_DIR}
+      FILES ${ARGS_INCLUDE_DIR}/${ARGS_HEADER_DIR}/${ARGS_FILENAME}
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ARGS_HEADER_DIR}
       PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE)
-  endif(INSTALL_GENERATED_HEADERS)
-endfunction(GENERATE_CONFIGURATION_HEADER)
+  endif()
+endfunction(GENERATE_CONFIGURATION_HEADER_V2)
 
 # _SETUP_PROJECT_HEADER_FINALIZE
 # ------------------------------

--- a/header.cmake
+++ b/header.cmake
@@ -150,9 +150,9 @@ endmacro(_SETUP_PROJECT_HEADER)
 # customize it.
 #
 # * HEADER_DIR    : where to generate the header
-# * FILENAME      : how should the file named
+# * FILENAME      : how the file should be named
 # * LIBRARY_NAME  : CPP symbol prefix, should match the compiled library name
-# * EXPORT_SYMBOl : what symbol controls the switch between symbol import/export
+# * EXPORT_SYMBOL : controls the switch between symbol import/export
 function(GENERATE_CONFIGURATION_HEADER HEADER_DIR FILENAME LIBRARY_NAME
          EXPORT_SYMBOL)
   # cmake-format: off
@@ -190,7 +190,7 @@ endfunction(GENERATE_CONFIGURATION_HEADER)
 # :param LIBRARY_NAME: CPP symbol prefix, should match the compiled library
 # name.
 #
-# :param EXPORT_SYMBOL: What symbol controls the switch between symbol
+# :param EXPORT_SYMBOL: Controls the switch between symbol
 # import/export.
 function(GENERATE_CONFIGURATION_HEADER_V2)
   set(options)

--- a/header.cmake
+++ b/header.cmake
@@ -174,9 +174,11 @@ endfunction(GENERATE_CONFIGURATION_HEADER)
 #   EXPORT_SYBMOL <export_symbol>)
 # ~~~
 #
-# This function generates a configuration header at ``<include_dir>/<header_dir>/<filename>``.
+# This function generates a configuration header at
+# ``<include_dir>/<header_dir>/<filename>``.
 #
-# If INSTALL_GENERATED_HEADERS is ON, the configuration header will be installed in
+# If INSTALL_GENERATED_HEADERS is ON, the configuration header will be installed
+# in
 # ``${CMAKE_INSTALL_INCLUDEDIR}/<header_dir>``.
 #
 # :param INCLUDE_DIR: Include root directory (absolute).
@@ -185,9 +187,11 @@ endfunction(GENERATE_CONFIGURATION_HEADER)
 #
 # :param FILENAME: Configuration header name.
 #
-# :param LIBRARY_NAME: CPP symbol prefix, should match the compiled library name.
+# :param LIBRARY_NAME: CPP symbol prefix, should match the compiled library
+# name.
 #
-# :param EXPORT_SYMBOL: What symbol controls the switch between symbol import/export.
+# :param EXPORT_SYMBOL: What symbol controls the switch between symbol
+# import/export.
 function(GENERATE_CONFIGURATION_HEADER_V2)
   set(options)
   set(oneValueArgs INCLUDE_DIR HEADER_DIR FILENAME LIBRARY_NAME EXPORT_SYMBOL)

--- a/test.cmake
+++ b/test.cmake
@@ -210,8 +210,13 @@ macro(ADD_PYTHON_MEMORYCHECK_UNIT_TEST NAME SOURCE)
                                       ${ARGN})
 endmacro()
 
-# .rst: .. command:: ADD_PYTHON_MEMORYCHECK_UNIT_TEST_V2 ( NAME <name> SOURCE
-# <source> [SUPP <supp>] [MODULES <modules>...])
+# ~~~
+# .rst: .. command:: ADD_PYTHON_MEMORYCHECK_UNIT_TEST_V2(
+#   NAME <name>
+#   SOURCE <source>
+#   [SUPP <supp>]
+#   [MODULES <modules>...])
+# ~~~
 #
 # Add a test that run a Python script through Valgrind to test if a Python
 # script leak memory.
@@ -226,8 +231,9 @@ endmacro()
 # :param MODULES: Set the `PYTHONPATH` environment variable to
 # `CMAKE_BINARY_DIR/<modules>...`.
 #
-# .. note:: :command:`FINDPYTHON` should have been called first. .. note:: Only
-# work if valgrind is installed
+# .. note:: :command:`FINDPYTHON` should have been called first.
+#
+# .. note:: Only work if valgrind is installed.
 macro(ADD_PYTHON_MEMORYCHECK_UNIT_TEST_V2)
   if(MEMORYCHECK_COMMAND AND MEMORYCHECK_COMMAND MATCHES ".*valgrind$")
     set(options)


### PR DESCRIPTION
Add a way to specify include dir in GENERATE_CONFIGURATION_HEADER.

Use modern cmake parameter parsing to avoid breaking the API in each change.