### PR TITLE
Add package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <description>CMake utility toolbox</description>
 
   <maintainer email="justin.carpentier@inria.fr">Justin Carpentier</maintainer>
-  <maintainer email="gsaurel@laas.fr">Guilhem Saurel</maintainer>
+  <maintainer email="guilhem.saurel@laas.fr">Guilhem Saurel</maintainer>
   <maintainer email="fill.me@in.com">Pierre Gergondet</maintainer>
 
 

--- a/package.xml
+++ b/package.xml
@@ -4,10 +4,9 @@
   <version>0.0.0</version>
   <description>CMake utility toolbox</description>
 
-  <maintainer email="justin.carpentier@inria.fr">Justin Carpentier</maintainer>
   <maintainer email="guilhem.saurel@laas.fr">Guilhem Saurel</maintainer>
-  <maintainer email="fill.me@in.com">Pierre Gergondet</maintainer>
-
+  <author>Justin Carpentier</author>
+  <author>Pierre Gergondet</author>
 
   <license>BSD-2</license>
   <url type="website">https://github.com/jrl-umi3218/jrl-cmakemodules</url>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>jrl-cmakemodules</name>
+  <version>0.0.0</version>
+  <description>CMake utility toolbox</description>
+
+  <maintainer email="justin.carpentier@inria.fr">Justin Carpentier</maintainer>
+  <maintainer email="gsaurel@laas.fr">Guilhem Saurel</maintainer>
+  <maintainer email="fill.me@in.com">Pierre Gergondet</maintainer>
+
+
+  <license>BSD-2</license>
+  <url type="website">https://github.com/jrl-umi3218/jrl-cmakemodules</url>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Add a package.xml file so one can use this package as a dependency directly.
I added a list of maintainer in this file.
It's hard to decide in practice as this project has many maintainers and contributors.
So I picked 3 names among the most commiters according to github...
If it's not politically correct tell me I could:
- remove the list altogether and let the people contact the maintainers from the github utils.
- add people in this list
- remove people in this list
- others?