### PR TITLE
find-external: remove suffix from library names

### DIFF
--- a/find-external/CDD/FindCDD.cmake
+++ b/find-external/CDD/FindCDD.cmake
@@ -29,7 +29,7 @@ find_path(
   PATH_SUFFIXES include/cdd include/cddlib)
 find_library(
   CDD_LIBRARY
-  NAMES libcdd.so
+  NAMES libcdd
   PATHS ${CDD_PREFIX})
 
 set(CDD_LIBRARIES ${CDD_LIBRARY})

--- a/find-external/CLP/FindCLP.cmake
+++ b/find-external/CLP/FindCLP.cmake
@@ -28,7 +28,7 @@ find_path(
   PATHS ${CLP_PREFIX})
 find_library(
   CLP_LIBRARY
-  NAMES libclp.so libClp.so
+  NAMES libclp libClp
   PATHS ${CLP_PREFIX})
 
 set(CLP_LIBRARIES ${CLP_LIBRARY})

--- a/find-external/CoinUtils/FindCoinUtils.cmake
+++ b/find-external/CoinUtils/FindCoinUtils.cmake
@@ -29,7 +29,7 @@ find_path(
   PATHS ${CoinUtils_PREFIX})
 find_library(
   CoinUtils_LIBRARY
-  NAMES libCoinUtils.so
+  NAMES libCoinUtils
   PATHS ${CoinUtils_PREFIX})
 
 set(CoinUtils_LIBRARIES ${CoinUtils_LIBRARY})

--- a/find-external/glpk/Findglpk.cmake
+++ b/find-external/glpk/Findglpk.cmake
@@ -28,7 +28,7 @@ find_path(
   PATHS ${glpk_PREFIX})
 find_library(
   glpk_LIBRARY
-  NAMES libglpk.so
+  NAMES libglpk
   PATHS ${glpk_PREFIX}
   PATH_SUFFIXES include/glpk)
 


### PR DESCRIPTION
to fix build for macos .dylib