### PR TITLE
forward COMPONENT parametert in install instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ project(
   ${PROJECT_NAME}
   DESCRIPTION ${PROJECT_DESCRIPTION}
   LANGUAGES CXX
-  VERSION 0.0.0)
+  VERSION 0.0.0
+)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   # Generate CMake exports
@@ -20,113 +21,119 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   # Add a dummy library with a useful INTERFACE_INCLUDE_DIRECTORIES
   add_library(${PROJECT_NAME} INTERFACE)
   set(INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}")
-  target_include_directories(${PROJECT_NAME}
-                             INTERFACE $<INSTALL_INTERFACE:${INSTALL_DIR}>)
+  target_include_directories(
+    ${PROJECT_NAME}
+    INTERFACE $<INSTALL_INTERFACE:${INSTALL_DIR}>
+  )
 
   # find . -maxdepth 1 -type d ! -path './.*' | sort
   install(
-    DIRECTORY ./boost
-              ./cython
-              ./doxygen
-              ./dynamic_graph
-              ./find-external
-              ./github
-              ./gtest
-              ./hpp
-              ./image
-              ./sphinx
-              ./stubgen
-              ./_unittests
-    DESTINATION ${INSTALL_DIR})
+    DIRECTORY
+      ./boost
+      ./cython
+      ./doxygen
+      ./dynamic_graph
+      ./find-external
+      ./github
+      ./gtest
+      ./hpp
+      ./image
+      ./sphinx
+      ./stubgen
+      ./_unittests
+    DESTINATION ${INSTALL_DIR}
+  )
 
   # find . -maxdepth 1 -type f ! -path './.*' | sort
   install(
-    FILES ./announce-gen
-          ./apple.cmake
-          ./base.cmake
-          ./boost.cmake
-          ./catkin.cmake
-          ./CMakeLists.txt
-          ./cmake_reinstall.cmake.in
-          ./cmake_uninstall.cmake.in
-          ./compiler.cmake
-          ./componentConfig.cmake.in
-          ./Config.cmake.in
-          ./config.h.cmake
-          ./config.hh.cmake
-          ./coverage.cmake
-          ./cpack.cmake
-          ./createshexe.cmake
-          ./cxx11.cmake
-          ./cxx-standard.cmake
-          ./debian.cmake
-          ./deprecated.hh.cmake
-          ./distcheck.cmake
-          ./dist.cmake
-          ./doxygen.cmake
-          ./eigen.cmake
-          ./filefilter.txt
-          ./fix-license.sh
-          ./geometric-tools.cmake
-          ./git-archive-all.py
-          ./git-archive-all.sh
-          ./gitlog-to-changelog
-          ./GNUInstallDirs.cmake
-          ./gtest.cmake
-          ./header.cmake
-          ./hpp.cmake
-          ./ide.cmake
-          ./idl.cmake
-          ./idlrtc.cmake
-          ./install-data.cmake
-          ./install-helpers.cmake
-          ./julia.cmake
-          ./kineo.cmake
-          ./lapack.cmake
-          ./LICENSE
-          ./logging.cmake
-          ./man.cmake
-          ./memorycheck_unit_test.cmake.in
-          ./metapodfromurdf.cmake
-          ./modernize-links.cmake
-          ./msvc-specific.cmake
-          ./msvc.vcxproj.user.in
-          ./openhrp.cmake
-          ./openhrpcontroller.cmake
-          ./openrtm.cmake
-          ./oscheck.cmake
-          ./package-config.cmake
-          ./package.xml
-          ./pixi.py
-          ./pkg-config.cmake
-          ./pkg-config.pc.cmake
-          ./portability.cmake
-          ./post-project.cmake
-          ./pthread.cmake
-          ./pyproject.py
-          ./python.cmake
-          ./python-helpers.cmake
-          ./qhull.cmake
-          ./README.md
-          ./release.cmake
-          ./relpath.cmake
-          ./ros.cmake
-          ./sdformat.cmake
-          ./setup.cfg
-          ./shared-library.cmake
-          ./sphinx.cmake
-          ./stubs.cmake
-          ./swig.cmake
-          ./test.cmake
-          ./tracy.cmake
-          ./tracy.hh.cmake
-          ./uninstall.cmake
-          ./version.cmake
-          ./version-script.cmake
-          ./version-script-test.lds
-          ./warning.hh.cmake
-          ./xacro.cmake
-    DESTINATION ${INSTALL_DIR})
+    FILES
+      ./announce-gen
+      ./apple.cmake
+      ./base.cmake
+      ./boost.cmake
+      ./catkin.cmake
+      ./CMakeLists.txt
+      ./cmake_reinstall.cmake.in
+      ./cmake_uninstall.cmake.in
+      ./compiler.cmake
+      ./componentConfig.cmake.in
+      ./Config.cmake.in
+      ./config.h.cmake
+      ./config.hh.cmake
+      ./coverage.cmake
+      ./cpack.cmake
+      ./createshexe.cmake
+      ./cxx11.cmake
+      ./cxx-standard.cmake
+      ./debian.cmake
+      ./deprecated.hh.cmake
+      ./distcheck.cmake
+      ./dist.cmake
+      ./doxygen.cmake
+      ./eigen.cmake
+      ./filefilter.txt
+      ./fix-license.sh
+      ./geometric-tools.cmake
+      ./git-archive-all.py
+      ./git-archive-all.sh
+      ./gitlog-to-changelog
+      ./GNUInstallDirs.cmake
+      ./gtest.cmake
+      ./header.cmake
+      ./hpp.cmake
+      ./ide.cmake
+      ./idl.cmake
+      ./idlrtc.cmake
+      ./install-data.cmake
+      ./install-helpers.cmake
+      ./julia.cmake
+      ./kineo.cmake
+      ./lapack.cmake
+      ./LICENSE
+      ./logging.cmake
+      ./man.cmake
+      ./memorycheck_unit_test.cmake.in
+      ./metapodfromurdf.cmake
+      ./modernize-links.cmake
+      ./msvc-specific.cmake
+      ./msvc.vcxproj.user.in
+      ./openhrp.cmake
+      ./openhrpcontroller.cmake
+      ./openrtm.cmake
+      ./oscheck.cmake
+      ./package-config.cmake
+      ./package.xml
+      ./pixi.py
+      ./pkg-config.cmake
+      ./pkg-config.pc.cmake
+      ./portability.cmake
+      ./post-project.cmake
+      ./pthread.cmake
+      ./pyproject.py
+      ./python.cmake
+      ./python-helpers.cmake
+      ./qhull.cmake
+      ./README.md
+      ./release.cmake
+      ./relpath.cmake
+      ./ros.cmake
+      ./sdformat.cmake
+      ./setup.cfg
+      ./shared-library.cmake
+      ./sphinx.cmake
+      ./stubs.cmake
+      ./swig.cmake
+      ./test.cmake
+      ./tracy.cmake
+      ./tracy.hh.cmake
+      ./uninstall.cmake
+      ./version.cmake
+      ./version-script.cmake
+      ./version-script-test.lds
+      ./warning.hh.cmake
+      ./xacro.cmake
+    DESTINATION ${INSTALL_DIR}
+  )
 
   install(TARGETS ${PROJECT_NAME} EXPORT ${TARGETS_EXPORT_NAME})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ project(
   ${PROJECT_NAME}
   DESCRIPTION ${PROJECT_DESCRIPTION}
   LANGUAGES CXX
-  VERSION 0.0.0
-)
+  VERSION 0.0.0)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   # Generate CMake exports
@@ -21,117 +20,113 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   # Add a dummy library with a useful INTERFACE_INCLUDE_DIRECTORIES
   add_library(${PROJECT_NAME} INTERFACE)
   set(INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}")
-  target_include_directories(
-    ${PROJECT_NAME}
-    INTERFACE $<INSTALL_INTERFACE:${INSTALL_DIR}>
-  )
+  target_include_directories(${PROJECT_NAME}
+                             INTERFACE $<INSTALL_INTERFACE:${INSTALL_DIR}>)
 
   # find . -maxdepth 1 -type d ! -path './.*' | sort
   install(
-    DIRECTORY
-      ./boost
-      ./cython
-      ./doxygen
-      ./dynamic_graph
-      ./find-external
-      ./github
-      ./gtest
-      ./hpp
-      ./image
-      ./sphinx
-      ./stubgen
-      ./_unittests
-    DESTINATION ${INSTALL_DIR}
-  )
+    DIRECTORY ./boost
+              ./cython
+              ./doxygen
+              ./dynamic_graph
+              ./find-external
+              ./github
+              ./gtest
+              ./hpp
+              ./image
+              ./sphinx
+              ./stubgen
+              ./_unittests
+    DESTINATION ${INSTALL_DIR})
 
   # find . -maxdepth 1 -type f ! -path './.*' | sort
   install(
-    FILES
-      ./announce-gen
-      ./apple.cmake
-      ./base.cmake
-      ./boost.cmake
-      ./catkin.cmake
-      ./CMakeLists.txt
-      ./cmake_reinstall.cmake.in
-      ./cmake_uninstall.cmake.in
-      ./compiler.cmake
-      ./componentConfig.cmake.in
-      ./Config.cmake.in
-      ./config.h.cmake
-      ./config.hh.cmake
-      ./coverage.cmake
-      ./cpack.cmake
-      ./createshexe.cmake
-      ./cxx11.cmake
-      ./cxx-standard.cmake
-      ./debian.cmake
-      ./deprecated.hh.cmake
-      ./distcheck.cmake
-      ./dist.cmake
-      ./doxygen.cmake
-      ./eigen.cmake
-      ./filefilter.txt
-      ./fix-license.sh
-      ./geometric-tools.cmake
-      ./git-archive-all.py
-      ./git-archive-all.sh
-      ./gitlog-to-changelog
-      ./GNUInstallDirs.cmake
-      ./gtest.cmake
-      ./header.cmake
-      ./hpp.cmake
-      ./ide.cmake
-      ./idl.cmake
-      ./idlrtc.cmake
-      ./install-data.cmake
-      ./julia.cmake
-      ./kineo.cmake
-      ./lapack.cmake
-      ./LICENSE
-      ./logging.cmake
-      ./man.cmake
-      ./memorycheck_unit_test.cmake.in
-      ./metapodfromurdf.cmake
-      ./modernize-links.cmake
-      ./msvc-specific.cmake
-      ./msvc.vcxproj.user.in
-      ./openhrp.cmake
-      ./openhrpcontroller.cmake
-      ./openrtm.cmake
-      ./oscheck.cmake
-      ./package-config.cmake
-      ./pkg-config.cmake
-      ./pkg-config.pc.cmake
-      ./portability.cmake
-      ./post-project.cmake
-      ./pthread.cmake
-      ./pyproject.py
-      ./python.cmake
-      ./python-helpers.cmake
-      ./qhull.cmake
-      ./README.md
-      ./release.cmake
-      ./relpath.cmake
-      ./ros.cmake
-      ./ros2.cmake
-      ./sdformat.cmake
-      ./setup.cfg
-      ./shared-library.cmake
-      ./sphinx.cmake
-      ./stubs.cmake
-      ./swig.cmake
-      ./test.cmake
-      ./tracy.cmake
-      ./tracy.hh.cmake
-      ./uninstall.cmake
-      ./version.cmake
-      ./version-script.cmake
-      ./version-script-test.lds
-      ./warning.hh.cmake
-      ./xacro.cmake
-    DESTINATION ${INSTALL_DIR}
-  )
+    FILES ./announce-gen
+          ./apple.cmake
+          ./base.cmake
+          ./boost.cmake
+          ./catkin.cmake
+          ./CMakeLists.txt
+          ./cmake_reinstall.cmake.in
+          ./cmake_uninstall.cmake.in
+          ./compiler.cmake
+          ./componentConfig.cmake.in
+          ./Config.cmake.in
+          ./config.h.cmake
+          ./config.hh.cmake
+          ./coverage.cmake
+          ./cpack.cmake
+          ./createshexe.cmake
+          ./cxx11.cmake
+          ./cxx-standard.cmake
+          ./debian.cmake
+          ./deprecated.hh.cmake
+          ./distcheck.cmake
+          ./dist.cmake
+          ./doxygen.cmake
+          ./eigen.cmake
+          ./filefilter.txt
+          ./fix-license.sh
+          ./geometric-tools.cmake
+          ./git-archive-all.py
+          ./git-archive-all.sh
+          ./gitlog-to-changelog
+          ./GNUInstallDirs.cmake
+          ./gtest.cmake
+          ./header.cmake
+          ./hpp.cmake
+          ./ide.cmake
+          ./idl.cmake
+          ./idlrtc.cmake
+          ./install-data.cmake
+          ./install-helpers.cmake
+          ./julia.cmake
+          ./kineo.cmake
+          ./lapack.cmake
+          ./LICENSE
+          ./logging.cmake
+          ./man.cmake
+          ./memorycheck_unit_test.cmake.in
+          ./metapodfromurdf.cmake
+          ./modernize-links.cmake
+          ./msvc-specific.cmake
+          ./msvc.vcxproj.user.in
+          ./openhrp.cmake
+          ./openhrpcontroller.cmake
+          ./openrtm.cmake
+          ./oscheck.cmake
+          ./package-config.cmake
+          ./package.xml
+          ./pixi.py
+          ./pkg-config.cmake
+          ./pkg-config.pc.cmake
+          ./portability.cmake
+          ./post-project.cmake
+          ./pthread.cmake
+          ./pyproject.py
+          ./python.cmake
+          ./python-helpers.cmake
+          ./qhull.cmake
+          ./README.md
+          ./release.cmake
+          ./relpath.cmake
+          ./ros.cmake
+          ./sdformat.cmake
+          ./setup.cfg
+          ./shared-library.cmake
+          ./sphinx.cmake
+          ./stubs.cmake
+          ./swig.cmake
+          ./test.cmake
+          ./tracy.cmake
+          ./tracy.hh.cmake
+          ./uninstall.cmake
+          ./version.cmake
+          ./version-script.cmake
+          ./version-script-test.lds
+          ./warning.hh.cmake
+          ./xacro.cmake
+    DESTINATION ${INSTALL_DIR})
 
   install(TARGETS ${PROJECT_NAME} EXPORT ${TARGETS_EXPORT_NAME})
 endif()

--- a/header.cmake
+++ b/header.cmake
@@ -93,7 +93,8 @@ macro(_SETUP_PROJECT_HEADER)
     # Generate config.hh header.
     generate_configuration_header(
       ${HEADER_DIR} config.${PROJECT_CUSTOM_HEADER_EXTENSION}
-      ${PACKAGE_CPPNAME} ${PACKAGE_CPPNAME_LOWER}_EXPORTS)
+      ${PACKAGE_CPPNAME} ${PACKAGE_CPPNAME_LOWER}_EXPORTS
+    )
   endif()
 
   if(NOT PROJECT_GENERATED_HEADERS_SKIP_DEPRECATED)
@@ -101,14 +102,16 @@ macro(_SETUP_PROJECT_HEADER)
     configure_file(
       ${PROJECT_JRL_CMAKE_MODULE_DIR}/deprecated.hh.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/deprecated.${PROJECT_CUSTOM_HEADER_EXTENSION}
-      @ONLY)
+      @ONLY
+    )
 
     if(INSTALL_GENERATED_HEADERS)
       install(
         FILES
           ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/deprecated.${PROJECT_CUSTOM_HEADER_EXTENSION}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_DIR}
-        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE)
+        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
+      )
     endif(INSTALL_GENERATED_HEADERS)
   endif()
 
@@ -117,30 +120,36 @@ macro(_SETUP_PROJECT_HEADER)
     configure_file(
       ${PROJECT_JRL_CMAKE_MODULE_DIR}/warning.hh.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/warning.${PROJECT_CUSTOM_HEADER_EXTENSION}
-      @ONLY)
+      @ONLY
+    )
 
     if(INSTALL_GENERATED_HEADERS)
       install(
         FILES
           ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/warning.${PROJECT_CUSTOM_HEADER_EXTENSION}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_DIR}
-        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE)
+        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
+      )
     endif(INSTALL_GENERATED_HEADERS)
   endif()
 
   # Generate config.h header. This header, unlike the previous one is *not*
   # installed and is generated in the top-level directory of the build tree.
   # Therefore it must not be included by any distributed header.
-  configure_file(${PROJECT_JRL_CMAKE_MODULE_DIR}/config.h.cmake
-                 ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+  configure_file(
+    ${PROJECT_JRL_CMAKE_MODULE_DIR}/config.h.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/config.h
+  )
 
   # Default include directories: - top-level build directory (for generated
   # non-distributed headers). - include directory in the build tree (for
   # generated, distributed headers). - include directory in the source tree
   # (non-generated, distributed headers).
   include_directories(
-    ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/include
-    ${PROJECT_SOURCE_DIR}/include)
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include
+  )
 endmacro(_SETUP_PROJECT_HEADER)
 
 # GENERATE_CONFIGURATION_HEADER
@@ -153,8 +162,13 @@ endmacro(_SETUP_PROJECT_HEADER)
 # * FILENAME      : how the file should be named
 # * LIBRARY_NAME  : CPP symbol prefix, should match the compiled library name
 # * EXPORT_SYMBOL : controls the switch between symbol import/export
-function(GENERATE_CONFIGURATION_HEADER HEADER_DIR FILENAME LIBRARY_NAME
-         EXPORT_SYMBOL)
+function(
+  GENERATE_CONFIGURATION_HEADER
+  HEADER_DIR
+  FILENAME
+  LIBRARY_NAME
+  EXPORT_SYMBOL
+)
   generate_configuration_header_v2(
     INCLUDE_DIR
     ${CMAKE_CURRENT_BINARY_DIR}/include
@@ -165,7 +179,8 @@ function(GENERATE_CONFIGURATION_HEADER HEADER_DIR FILENAME LIBRARY_NAME
     LIBRARY_NAME
     ${LIBRARY_NAME}
     EXPORT_SYMBOL
-    ${EXPORT_SYMBOL})
+    ${EXPORT_SYMBOL}
+  )
 endfunction(GENERATE_CONFIGURATION_HEADER)
 
 # ~~~
@@ -196,10 +211,22 @@ endfunction(GENERATE_CONFIGURATION_HEADER)
 # :param EXPORT_SYMBOL: Controls the switch between symbol import/export.
 function(GENERATE_CONFIGURATION_HEADER_V2)
   set(options)
-  set(oneValueArgs INCLUDE_DIR HEADER_DIR FILENAME LIBRARY_NAME EXPORT_SYMBOL)
+  set(
+    oneValueArgs
+    INCLUDE_DIR
+    HEADER_DIR
+    FILENAME
+    LIBRARY_NAME
+    EXPORT_SYMBOL
+  )
   set(multiValueArgs)
-  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
-                        ${ARGN})
+  cmake_parse_arguments(
+    ARGS
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
 
   if(${PROJECT_VERSION_MAJOR} MATCHES UNKNOWN)
     set(PROJECT_VERSION_MAJOR_CONFIG ${ARGS_LIBRARY_NAME}_VERSION_UNKNOWN_TAG)
@@ -224,15 +251,19 @@ function(GENERATE_CONFIGURATION_HEADER_V2)
   set(LIBRARY_NAME ${ARGS_LIBRARY_NAME})
 
   # Generate the header.
-  configure_file(${PROJECT_JRL_CMAKE_MODULE_DIR}/config.hh.cmake
-                 ${ARGS_INCLUDE_DIR}/${ARGS_HEADER_DIR}/${ARGS_FILENAME} @ONLY)
+  configure_file(
+    ${PROJECT_JRL_CMAKE_MODULE_DIR}/config.hh.cmake
+    ${ARGS_INCLUDE_DIR}/${ARGS_HEADER_DIR}/${ARGS_FILENAME}
+    @ONLY
+  )
 
   # Install it if requested.
   if(INSTALL_GENERATED_HEADERS)
     install(
       FILES ${ARGS_INCLUDE_DIR}/${ARGS_HEADER_DIR}/${ARGS_FILENAME}
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ARGS_HEADER_DIR}
-      PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE)
+      PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
+    )
   endif()
 endfunction(GENERATE_CONFIGURATION_HEADER_V2)
 
@@ -264,8 +295,13 @@ macro(HEADER_INSTALL)
   set(options)
   set(oneValueArgs COMPONENT)
   set(multiValueArgs)
-  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
-                        ${ARGN})
+  cmake_parse_arguments(
+    ARGS
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
 
   if(ARGS_COMPONENT)
     set(_COMPONENT_NAME ${ARGS_COMPONENT})
@@ -284,6 +320,7 @@ macro(HEADER_INSTALL)
       FILES ${FILE}
       DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${DIR}"
       PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
-      COMPONENT ${_COMPONENT_NAME})
+      COMPONENT ${_COMPONENT_NAME}
+    )
   endforeach()
 endmacro()

--- a/header.cmake
+++ b/header.cmake
@@ -93,8 +93,7 @@ macro(_SETUP_PROJECT_HEADER)
     # Generate config.hh header.
     generate_configuration_header(
       ${HEADER_DIR} config.${PROJECT_CUSTOM_HEADER_EXTENSION}
-      ${PACKAGE_CPPNAME} ${PACKAGE_CPPNAME_LOWER}_EXPORTS
-    )
+      ${PACKAGE_CPPNAME} ${PACKAGE_CPPNAME_LOWER}_EXPORTS)
   endif()
 
   if(NOT PROJECT_GENERATED_HEADERS_SKIP_DEPRECATED)
@@ -102,16 +101,14 @@ macro(_SETUP_PROJECT_HEADER)
     configure_file(
       ${PROJECT_JRL_CMAKE_MODULE_DIR}/deprecated.hh.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/deprecated.${PROJECT_CUSTOM_HEADER_EXTENSION}
-      @ONLY
-    )
+      @ONLY)
 
     if(INSTALL_GENERATED_HEADERS)
       install(
         FILES
           ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/deprecated.${PROJECT_CUSTOM_HEADER_EXTENSION}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_DIR}
-        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
-      )
+        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE)
     endif(INSTALL_GENERATED_HEADERS)
   endif()
 
@@ -120,36 +117,30 @@ macro(_SETUP_PROJECT_HEADER)
     configure_file(
       ${PROJECT_JRL_CMAKE_MODULE_DIR}/warning.hh.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/warning.${PROJECT_CUSTOM_HEADER_EXTENSION}
-      @ONLY
-    )
+      @ONLY)
 
     if(INSTALL_GENERATED_HEADERS)
       install(
         FILES
           ${CMAKE_CURRENT_BINARY_DIR}/include/${HEADER_DIR}/warning.${PROJECT_CUSTOM_HEADER_EXTENSION}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_DIR}
-        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
-      )
+        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE)
     endif(INSTALL_GENERATED_HEADERS)
   endif()
 
   # Generate config.h header. This header, unlike the previous one is *not*
   # installed and is generated in the top-level directory of the build tree.
   # Therefore it must not be included by any distributed header.
-  configure_file(
-    ${PROJECT_JRL_CMAKE_MODULE_DIR}/config.h.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/config.h
-  )
+  configure_file(${PROJECT_JRL_CMAKE_MODULE_DIR}/config.h.cmake
+                 ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
   # Default include directories: - top-level build directory (for generated
   # non-distributed headers). - include directory in the build tree (for
   # generated, distributed headers). - include directory in the source tree
   # (non-generated, distributed headers).
   include_directories(
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/include
-    ${PROJECT_SOURCE_DIR}/include
-  )
+    ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include)
 endmacro(_SETUP_PROJECT_HEADER)
 
 # GENERATE_CONFIGURATION_HEADER
@@ -162,20 +153,19 @@ endmacro(_SETUP_PROJECT_HEADER)
 # * FILENAME      : how the file should be named
 # * LIBRARY_NAME  : CPP symbol prefix, should match the compiled library name
 # * EXPORT_SYMBOL : controls the switch between symbol import/export
-function(
-  GENERATE_CONFIGURATION_HEADER
-  HEADER_DIR
-  FILENAME
-  LIBRARY_NAME
-  EXPORT_SYMBOL
-)
+function(GENERATE_CONFIGURATION_HEADER HEADER_DIR FILENAME LIBRARY_NAME
+         EXPORT_SYMBOL)
   generate_configuration_header_v2(
-    INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include
-    HEADER_DIR ${HEADER_DIR}
-    FILENAME ${FILENAME}
-    LIBRARY_NAME ${LIBRARY_NAME}
-    EXPORT_SYMBOL ${EXPORT_SYMBOL}
-  )
+    INCLUDE_DIR
+    ${CMAKE_CURRENT_BINARY_DIR}/include
+    HEADER_DIR
+    ${HEADER_DIR}
+    FILENAME
+    ${FILENAME}
+    LIBRARY_NAME
+    ${LIBRARY_NAME}
+    EXPORT_SYMBOL
+    ${EXPORT_SYMBOL})
 endfunction(GENERATE_CONFIGURATION_HEADER)
 
 # ~~~
@@ -206,22 +196,10 @@ endfunction(GENERATE_CONFIGURATION_HEADER)
 # :param EXPORT_SYMBOL: Controls the switch between symbol import/export.
 function(GENERATE_CONFIGURATION_HEADER_V2)
   set(options)
-  set(
-    oneValueArgs
-    INCLUDE_DIR
-    HEADER_DIR
-    FILENAME
-    LIBRARY_NAME
-    EXPORT_SYMBOL
-  )
+  set(oneValueArgs INCLUDE_DIR HEADER_DIR FILENAME LIBRARY_NAME EXPORT_SYMBOL)
   set(multiValueArgs)
-  cmake_parse_arguments(
-    ARGS
-    "${options}"
-    "${oneValueArgs}"
-    "${multiValueArgs}"
-    ${ARGN}
-  )
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
 
   if(${PROJECT_VERSION_MAJOR} MATCHES UNKNOWN)
     set(PROJECT_VERSION_MAJOR_CONFIG ${ARGS_LIBRARY_NAME}_VERSION_UNKNOWN_TAG)
@@ -246,19 +224,15 @@ function(GENERATE_CONFIGURATION_HEADER_V2)
   set(LIBRARY_NAME ${ARGS_LIBRARY_NAME})
 
   # Generate the header.
-  configure_file(
-    ${PROJECT_JRL_CMAKE_MODULE_DIR}/config.hh.cmake
-    ${ARGS_INCLUDE_DIR}/${ARGS_HEADER_DIR}/${ARGS_FILENAME}
-    @ONLY
-  )
+  configure_file(${PROJECT_JRL_CMAKE_MODULE_DIR}/config.hh.cmake
+                 ${ARGS_INCLUDE_DIR}/${ARGS_HEADER_DIR}/${ARGS_FILENAME} @ONLY)
 
   # Install it if requested.
   if(INSTALL_GENERATED_HEADERS)
     install(
       FILES ${ARGS_INCLUDE_DIR}/${ARGS_HEADER_DIR}/${ARGS_FILENAME}
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ARGS_HEADER_DIR}
-      PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
-    )
+      PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE)
   endif()
 endfunction(GENERATE_CONFIGURATION_HEADER_V2)
 
@@ -271,19 +245,36 @@ endfunction(GENERATE_CONFIGURATION_HEADER_V2)
 macro(_SETUP_PROJECT_HEADER_FINALIZE)
   # If the header list is set, install it.
   if(DEFINED ${PROJECT_NAME}_HEADERS)
-    foreach(FILE ${${PROJECT_NAME}_HEADERS})
-      header_install(${FILE})
-    endforeach(FILE)
+    header_install(${${PROJECT_NAME}_HEADERS})
   endif(DEFINED ${PROJECT_NAME}_HEADERS)
 endmacro(_SETUP_PROJECT_HEADER_FINALIZE)
 
 # .rst: .. ifmode:: internal
 #
-# .. command:: HEADER_INSTALL (FILES)
+# ~~~
+# .. command:: HEADER_INSTALL (COMPONENT <component> <files>...)
+# ~~~
 #
 # Install a list of headers.
 #
-macro(HEADER_INSTALL FILES)
+# :param component: Component to forward to install command.
+#
+# :param files: Files to install.
+macro(HEADER_INSTALL)
+  set(options)
+  set(oneValueArgs COMPONENT)
+  set(multiValueArgs)
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
+
+  if(ARGS_COMPONENT)
+    set(_COMPONENT_NAME ${ARGS_COMPONENT})
+  else()
+    set(_COMPONENT_NAME ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME})
+  endif()
+
+  set(FILES ${ARGS_UNPARSED_ARGUMENTS})
+
   foreach(FILE ${FILES})
     get_filename_component(DIR "${FILE}" PATH)
     string(REGEX REPLACE "${CMAKE_BINARY_DIR}" "" DIR "${DIR}")
@@ -293,6 +284,6 @@ macro(HEADER_INSTALL FILES)
       FILES ${FILE}
       DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${DIR}"
       PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE
-    )
+      COMPONENT ${_COMPONENT_NAME})
   endforeach()
 endmacro()

--- a/install-helpers.cmake
+++ b/install-helpers.cmake
@@ -1,0 +1,41 @@
+# Copyright (C) 2024 INRIA.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# .rst:
+# ~~~
+# .. command:: ADD_INSTALL_TARGET (
+#   NAME <name>
+#   COMPONENT <component>)
+# ~~~
+#
+# This function add a custom target named install-<name> that will run cmake
+# install for a specific <component>.
+#
+# :param name: Target name suffix (install-<name>).
+#
+# :param component: component to install.
+function(ADD_INSTALL_TARGET)
+  set(options)
+  set(oneValueArgs NAME COMPONENT)
+  set(multiValueArgs)
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
+  set(target_name install-${ARGS_NAME})
+  set(component ${ARGS_COMPONENT})
+
+  add_custom_target(
+    ${target_name} COMMAND ${CMAKE_COMMAND} -DCOMPONENT=${component} -P
+                           ${PROJECT_BINARY_DIR}/cmake_install.cmake)
+endfunction()

--- a/install-helpers.cmake
+++ b/install-helpers.cmake
@@ -30,12 +30,20 @@ function(ADD_INSTALL_TARGET)
   set(options)
   set(oneValueArgs NAME COMPONENT)
   set(multiValueArgs)
-  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
-                        ${ARGN})
+  cmake_parse_arguments(
+    ARGS
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
   set(target_name install-${ARGS_NAME})
   set(component ${ARGS_COMPONENT})
 
   add_custom_target(
-    ${target_name} COMMAND ${CMAKE_COMMAND} -DCOMPONENT=${component} -P
-                           ${PROJECT_BINARY_DIR}/cmake_install.cmake)
+    ${target_name}
+    COMMAND
+      ${CMAKE_COMMAND} -DCOMPONENT=${component} -P
+      ${PROJECT_BINARY_DIR}/cmake_install.cmake
+  )
 endfunction()

--- a/python-helpers.cmake
+++ b/python-helpers.cmake
@@ -32,8 +32,13 @@ macro(PYTHON_INSTALL MODULE FILE DEST)
   set(options)
   set(oneValueArgs COMPONENT)
   set(multiValueArgs)
-  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
-                        ${ARGN})
+  cmake_parse_arguments(
+    ARGS
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
 
   if(ARGS_COMPONENT)
     set(_COMPONENT_NAME ${ARGS_COMPONENT})
@@ -46,7 +51,8 @@ macro(PYTHON_INSTALL MODULE FILE DEST)
   install(
     FILES "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}/${FILE}"
     DESTINATION "${DEST}/${MODULE}"
-    COMPONENT ${_COMPONENT_NAME})
+    COMPONENT ${_COMPONENT_NAME}
+  )
 endmacro()
 
 # .rst:
@@ -66,8 +72,13 @@ macro(PYTHON_INSTALL_ON_SITE MODULE FILE)
   set(options)
   set(oneValueArgs COMPONENT)
   set(multiValueArgs)
-  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
-                        ${ARGN})
+  cmake_parse_arguments(
+    ARGS
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
 
   if(ARGS_COMPONENT)
     set(_COMPONENT_NAME ${ARGS_COMPONENT})
@@ -76,7 +87,8 @@ macro(PYTHON_INSTALL_ON_SITE MODULE FILE)
   endif()
 
   python_install("${MODULE}" "${FILE}" ${PYTHON_SITELIB} COMPONENT
-                 ${_COMPONENT_NAME})
+                 ${_COMPONENT_NAME}
+  )
 endmacro()
 
 # PYTHON_BUILD_GET_TARGET(TARGET)
@@ -86,17 +98,19 @@ endmacro()
 #
 function(PYTHON_BUILD_GET_TARGET python_build_target)
   # Regex from IsValidTargetName in CMake/Source/cmGeneratorExpression.cxx
-  string(REGEX
-         REPLACE "[^A-Za-z0-9_.+-]" "_" compile_pyc
-                 "${PROJECT_NAME}_compile_pyc_${CMAKE_CURRENT_SOURCE_DIR}")
+  string(
+    REGEX REPLACE
+    "[^A-Za-z0-9_.+-]"
+    "_"
+    compile_pyc
+    "${PROJECT_NAME}_compile_pyc_${CMAKE_CURRENT_SOURCE_DIR}"
+  )
 
   if(NOT TARGET ${compile_pyc})
     add_custom_target(${compile_pyc} ALL)
   endif()
 
-  set(${python_build_target}
-      ${compile_pyc}
-      PARENT_SCOPE)
+  set(${python_build_target} ${compile_pyc} PARENT_SCOPE)
 endfunction(PYTHON_BUILD_GET_TARGET NAME)
 
 # PYTHON_BUILD(MODULE FILE DEST)
@@ -123,7 +137,8 @@ macro(PYTHON_BUILD MODULE FILE)
   add_custom_command(
     TARGET ${python_build_target}
     PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTPUT_FILE_DIR}")
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTPUT_FILE_DIR}"
+  )
 
   python_build_file(${INPUT_FILE} ${OUTPUT_FILE})
 endmacro()
@@ -150,7 +165,8 @@ macro(PYTHON_BUILD_FILE FILE)
     COMMAND
       "${PYTHON_EXECUTABLE}" -c
       "import py_compile; py_compile.compile(\"${FILE}\",\"${OUTPUT_FILE}\")"
-    VERBATIM)
+    VERBATIM
+  )
 
   # Tag pyc file as generated.
   set_source_files_properties("${OUTPUT_FILE}" PROPERTIES GENERATED TRUE)
@@ -159,5 +175,6 @@ macro(PYTHON_BUILD_FILE FILE)
   set_property(
     DIRECTORY
     APPEND
-    PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${OUTPUT_FILE}")
+    PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${OUTPUT_FILE}"
+  )
 endmacro()


### PR DESCRIPTION
CMake install instruction support the [COMPONENT parameter](https://cmake.org/cmake/help/latest/command/install.html#id4) that allow to install some subpart of the package by doing `cmake -DCOMPONENT=<component_name> -P build/cmake_install.cmake`.

This will allow to more easily split our package into subpackage by creating custom installation rules.

Add the ADD_INSTALL_TARGET function to easily create a target to install a specific component.