### PR TITLE
ROS 2 file generation macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
           ./release.cmake
           ./relpath.cmake
           ./ros.cmake
+          ./ros2.cmake          
           ./sdformat.cmake
           ./setup.cfg
           ./shared-library.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
           ./release.cmake
           ./relpath.cmake
           ./ros.cmake
-          ./ros2.cmake          
+          ./ros2.cmake
           ./sdformat.cmake
           ./setup.cfg
           ./shared-library.cmake

--- a/base.cmake
+++ b/base.cmake
@@ -182,6 +182,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cxx-standard.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/coverage.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/modernize-links.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/relpath.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ros2.cmake)
 
 # --------- # Constants # --------- #
 

--- a/base.cmake
+++ b/base.cmake
@@ -353,6 +353,7 @@ macro(SETUP_PROJECT_FINALIZE)
   _setup_debian()
   # Install data if needed
   _install_project_data()
+  _install_project_ros2_ament_files()
 
   logging_finalize()
   if(PROJECT_USE_CMAKE_EXPORT)

--- a/ros2.cmake
+++ b/ros2.cmake
@@ -13,10 +13,9 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# This macro creates 3 files which are allowing a package to be found
-# using the AMENT system present in ros 2
-# Setting BUILDING_ROS2_PACKAGE is enough to trigger this behavior.
-# _install_project_ros2_ament_files()
+# This macro creates 3 files which are allowing a package to be found using the
+# AMENT system present in ros 2 Setting BUILDING_ROS2_PACKAGE is enough to
+# trigger this behavior. _install_project_ros2_ament_files()
 macro(_install_project_ros2_ament_files)
   if(BUILDING_ROS2_PACKAGE)
     message(STATUS "Create files for AMENT (ROS 2)")
@@ -27,7 +26,7 @@ macro(_install_project_ros2_ament_files)
       "")
     install(
       FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME}
+        ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME}
       DESTINATION share/ament_index/resource_index/packages)
     file(
       WRITE
@@ -35,13 +34,14 @@ macro(_install_project_ros2_ament_files)
       "prepend-non-duplicate;AMENT_PREFIX_PATH;")
     install(
       FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv
+        ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv
       DESTINATION share/${PROJECT_NAME}/hook)
     file(WRITE
-      ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
-      "prepend-non-duplicate;PYTHONPATH;${PYTHON_SITELIB}")
+         ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
+         "prepend-non-duplicate;PYTHONPATH;${PYTHON_SITELIB}")
     install(
-      FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
+      FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
       DESTINATION share/${PROJECT_NAME}/hook)
   endif(BUILDING_ROS2_PACKAGE)
 endmacro(_install_project_ros2_ament_files)

--- a/ros2.cmake
+++ b/ros2.cmake
@@ -1,0 +1,47 @@
+# Copyright (C) 2024 LAAS-CNRS, JRL AIST-CNRS.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This macro creates 3 files which are allowing a package to be found
+# using the AMENT system present in ros 2
+# Setting BUILDING_ROS2_PACKAGE is enough to trigger this behavior.
+# _install_project_ros2_ament_files()
+macro(_install_project_ros2_ament_files)
+  if(BUILDING_ROS2_PACKAGE)
+    message(STATUS "Create files for AMENT (ROS 2)")
+    # Allows Colcon to find non-Ament packages when using workspace underlays
+    file(
+      WRITE
+      ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME}
+      "")
+    install(
+      FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME}
+      DESTINATION share/ament_index/resource_index/packages)
+    file(
+      WRITE
+      ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv
+      "prepend-non-duplicate;AMENT_PREFIX_PATH;")
+    install(
+      FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv
+      DESTINATION share/${PROJECT_NAME}/hook)
+    file(WRITE
+      ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
+      "prepend-non-duplicate;PYTHONPATH;${PYTHON_SITELIB}")
+    install(
+      FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
+      DESTINATION share/${PROJECT_NAME}/hook)
+  endif(BUILDING_ROS2_PACKAGE)
+endmacro(_install_project_ros2_ament_files)


### PR DESCRIPTION
This is a proposal to fix #716.
This PR introduces a new file ros2.cmake.
It provides a macro _install_project_ros2_ament_files to generate files for the ROS2 ament system.
This macro is called in setup_project_finalize() in base.cmake.
The generation works if the variable BUILDING_ROS2_PACKAGE is set (to TRUE
for instance).

pre-commit was run over the PR.
Tested against unittest. 