### PR TITLE
Add FindIpopt.cmake module

### DIFF
--- a/find-external/Ipopt/FindIpopt.cmake
+++ b/find-external/Ipopt/FindIpopt.cmake
@@ -28,18 +28,29 @@ else()
   message(STATUS "  Ipopt library dirs: ${Ipopt_LIBRARY_DIRS}")
   message(STATUS "  Ipopt include dirs: ${Ipopt_INCLUDE_DIRS}")
   add_library(ipopt SHARED IMPORTED)
+  # On Windows, ipopt library is named ipopt-3
   find_library(
     ipopt_lib_path
-    NAMES ipopt
-    PATHS ${Ipopt_LIBRARY_DIRS})
+    NAMES ipopt ipopt-3
+    PATHS ${Ipopt_LIBRARY_DIRS} REQUIRED)
   message(STATUS "  Ipopt library found at ${ipopt_lib_path}")
-  set_target_properties(ipopt PROPERTIES IMPORTED_LOCATION ${ipopt_lib_path})
-  target_include_directories(ipopt INTERFACE ${Ipopt_INCLUDE_DIRS})
+  set_target_properties(
+    ipopt
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Ipopt_INCLUDE_DIRS}"
+               INTERFACE_COMPILE_OPTIONS "${Ipopt_CFLAGS_OTHER}"
+               IMPORTED_CONFIGURATIONS "RELEASE")
 
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_definitions(ipopt INTERFACE HAVE_CSTDDEF)
   endif()
-  target_compile_options(ipopt INTERFACE ${Ipopt_CFLAGS_OTHER})
+
+  if(WIN32)
+    set_target_properties(ipopt PROPERTIES IMPORTED_IMPLIB_RELEASE
+                                           "${ipopt_lib_path}")
+  else()
+    set_target_properties(ipopt PROPERTIES IMPORTED_LOCATION_RELEASE
+                                           "${ipopt_lib_path}")
+  endif()
 
   add_library(Ipopt::Ipopt ALIAS ipopt)
 endif()

--- a/find-external/Ipopt/FindIpopt.cmake
+++ b/find-external/Ipopt/FindIpopt.cmake
@@ -1,0 +1,47 @@
+# Copyright 2024 CNRS INRIA
+#
+# Author: Wilson Jallet
+#
+# Adapted from: https://github.com/casadi/casadi/blob/main/cmake/FindIPOPT.cmake
+#
+# Uses the modern PkgConfig CMake module helpers to find an installed version of Ipopt,
+# for which a CMake shared imported library target is created with the required includes and compile options in its link interface.
+#
+find_package(Ipopt CONFIG QUIET)
+
+if(Ipopt_FOUND)
+  message(DEBUG "Found Ipopt (using IpoptConfig.cmake or ipopt-config.cmake)")
+else()
+  find_package(PkgConfig QUIET)
+  if(NOT PKG_CONFIG_FOUND)
+    message(FATAL_ERROR "pkg-config not found!")
+  endif()
+  pkg_check_modules(Ipopt REQUIRED ipopt)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    Ipopt
+    FAIL_MESSAGE DEFAULT_MSG
+    REQUIRED_VARS Ipopt_INCLUDE_DIRS Ipopt_LIBRARIES
+    VERSION_VAR Ipopt_VERSION)
+
+  message(STATUS "  Ipopt library dirs: ${Ipopt_LIBRARY_DIRS}")
+  message(STATUS "  Ipopt include dirs: ${Ipopt_INCLUDE_DIRS}")
+  add_library(ipopt SHARED IMPORTED)
+  find_library(
+    ipopt_lib_path
+    NAMES ipopt
+    PATHS ${Ipopt_LIBRARY_DIRS})
+  message(STATUS "  Ipopt library ipopt found at ${ipopt_lib_path}")
+  set_target_properties(ipopt PROPERTIES IMPORTED_LOCATION ${ipopt_lib_path})
+  target_include_directories(ipopt INTERFACE ${Ipopt_INCLUDE_DIRS})
+
+  if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+
+  else()
+    target_compile_definitions(ipopt INTERFACE HAVE_CSTDDEF)
+  endif()
+  target_compile_options(ipopt INTERFACE ${Ipopt_CFLAGS_OTHER})
+
+  add_library(Ipopt::Ipopt ALIAS ipopt)
+endif()

--- a/find-external/Ipopt/FindIpopt.cmake
+++ b/find-external/Ipopt/FindIpopt.cmake
@@ -40,10 +40,6 @@ else()
                INTERFACE_COMPILE_OPTIONS "${Ipopt_CFLAGS_OTHER}"
                IMPORTED_CONFIGURATIONS "RELEASE")
 
-  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_compile_definitions(ipopt INTERFACE HAVE_CSTDDEF)
-  endif()
-
   if(WIN32)
     set_target_properties(ipopt PROPERTIES IMPORTED_IMPLIB_RELEASE
                                            "${ipopt_lib_path}")

--- a/find-external/Ipopt/FindIpopt.cmake
+++ b/find-external/Ipopt/FindIpopt.cmake
@@ -15,10 +15,7 @@ find_package(Ipopt CONFIG QUIET)
 if(Ipopt_FOUND)
   message(DEBUG "Found Ipopt (using IpoptConfig.cmake or ipopt-config.cmake)")
 else()
-  find_package(PkgConfig QUIET)
-  if(NOT PKG_CONFIG_FOUND)
-    message(FATAL_ERROR "pkg-config not found!")
-  endif()
+  find_package(PkgConfig REQUIRED)
   pkg_check_modules(Ipopt REQUIRED ipopt)
 
   include(FindPackageHandleStandardArgs)
@@ -35,13 +32,11 @@ else()
     ipopt_lib_path
     NAMES ipopt
     PATHS ${Ipopt_LIBRARY_DIRS})
-  message(STATUS "  Ipopt library ipopt found at ${ipopt_lib_path}")
+  message(STATUS "  Ipopt library found at ${ipopt_lib_path}")
   set_target_properties(ipopt PROPERTIES IMPORTED_LOCATION ${ipopt_lib_path})
   target_include_directories(ipopt INTERFACE ${Ipopt_INCLUDE_DIRS})
 
-  if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
-
-  else()
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_definitions(ipopt INTERFACE HAVE_CSTDDEF)
   endif()
   target_compile_options(ipopt INTERFACE ${Ipopt_CFLAGS_OTHER})

--- a/find-external/Ipopt/FindIpopt.cmake
+++ b/find-external/Ipopt/FindIpopt.cmake
@@ -2,7 +2,9 @@
 #
 # Author: Wilson Jallet
 #
-# Adapted from: https://github.com/casadi/casadi/blob/main/cmake/FindIPOPT.cmake
+# Adapted from:
+# https://github.com/casadi/casadi/blob/main/cmake/FindIPOPT.cmake, LGPL 3.0
+# License
 #
 # Uses the modern PkgConfig CMake module helpers to find an installed version of
 # Ipopt, for which a CMake shared imported library target is created with the

--- a/find-external/Ipopt/FindIpopt.cmake
+++ b/find-external/Ipopt/FindIpopt.cmake
@@ -4,8 +4,9 @@
 #
 # Adapted from: https://github.com/casadi/casadi/blob/main/cmake/FindIPOPT.cmake
 #
-# Uses the modern PkgConfig CMake module helpers to find an installed version of Ipopt,
-# for which a CMake shared imported library target is created with the required includes and compile options in its link interface.
+# Uses the modern PkgConfig CMake module helpers to find an installed version of
+# Ipopt, for which a CMake shared imported library target is created with the
+# required includes and compile options in its link interface.
 #
 find_package(Ipopt CONFIG QUIET)
 


### PR DESCRIPTION
This PR:
- adds a FindIpopt.cmake module, which enables the use of `find_package(Ipopt)`