### PR TITLE
Remove Windows path separator in PYTHON_SITELIB

### DIFF
--- a/python.cmake
+++ b/python.cmake
@@ -292,9 +292,7 @@ macro(FINDPYTHON)
   message(STATUS "PythonLibraryDirs: ${PYTHON_LIBRARY_DIRS}")
   message(STATUS "PythonLibVersionString: ${PYTHONLIBS_VERSION_STRING}")
 
-  if(PYTHON_SITELIB)
-    file(TO_CMAKE_PATH "${PYTHON_SITELIB}" PYTHON_SITELIB)
-  else()
+  if(NOT PYTHON_SITELIB)
     # Use either site-packages (default) or dist-packages (Debian packages)
     # directory
     option(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
@@ -349,6 +347,11 @@ macro(FINDPYTHON)
         "${PYTHON_SITELIB}"
       )
     endif()
+  endif()
+
+  # Avoid Windows path
+  if(PYTHON_SITELIB)
+    file(TO_CMAKE_PATH "${PYTHON_SITELIB}" PYTHON_SITELIB)
   endif()
 
   message(STATUS "Python site lib: ${PYTHON_SITELIB}")

--- a/python.cmake
+++ b/python.cmake
@@ -349,7 +349,7 @@ macro(FINDPYTHON)
     endif()
   endif()
 
-  # Avoid Windows path
+  # Avoid paths in Windows format
   if(PYTHON_SITELIB)
     file(TO_CMAKE_PATH "${PYTHON_SITELIB}" PYTHON_SITELIB)
   endif()


### PR DESCRIPTION
When PYTHON_SITELIB is not provided and is searched from python interpreter call, the path in not normalized and can contains `\`.

This create an error when calling `python_install_on_site` macro.