### PR TITLE
Allow to launch distcheck with Ninja and also add Pixi support

### DIFF
--- a/distcheck.cmake
+++ b/distcheck.cmake
@@ -86,6 +86,8 @@ macro(DISTCHECK_SETUP)
         mkdir -p _inst &&
         chmod u+rwx _build _inst &&
         chmod a-w . &&
+        # Link xpixi directory into new source dir to avoid issue when replacing path in CMakeCache.txt
+        if [ -d ${CMAKE_SOURCE_DIR}/.pixi ]; then ( ln -s ${CMAKE_SOURCE_DIR}/.pixi ${SRCDIR}/.pixi ) ; fi &&
         cp ${CMAKE_BINARY_DIR}/CMakeCache.txt _build/ &&
         # Change previous source dir to the source one
         ${SED} ${SED_I_OPTION} -e "'s|${CMAKE_SOURCE_DIR}|${SRCDIR}|g'" _build/CMakeCache.txt &&

--- a/distcheck.cmake
+++ b/distcheck.cmake
@@ -68,6 +68,7 @@ macro(DISTCHECK_SETUP)
       "${CMAKE_BINARY_DIR}"
     )
 
+    set(BUILD_CMD ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target)
     if(NOT TARGET distcheck)
       add_custom_target(distcheck COMMENT "Checking generated tarball...")
     endif()
@@ -124,22 +125,22 @@ macro(DISTCHECK_SETUP)
           cmake .. ||
           (echo "ERROR: the cmake configuration failed." && false)
           &&
-        make ${DISTCHECK_MAKEFLAGS} ||
+        ${BUILD_CMD} ${DISTCHECK_MAKEFLAGS} all ||
           (echo "ERROR: the compilation failed." && false)
           &&
-        make test ||
+        ${BUILD_CMD} test ||
           (echo "ERROR: the test suite failed." && false)
           &&
-        make install ||
+        ${BUILD_CMD} install ||
           (echo "ERROR: the install target failed." && false)
           &&
-        make uninstall ||
+        ${BUILD_CMD} uninstall ||
           (echo "ERROR: the uninstall target failed." && false)
           &&
         test `find ${INSTDIR} -type f | wc -l` -eq 0 ||
           (echo "ERROR: the uninstall target does not work." && false)
           &&
-        make clean || (echo "ERROR: the clean target failed." && false)
+        ${BUILD_CMD} clean || (echo "ERROR: the clean target failed." && false)
           &&
         cd ${CMAKE_BINARY_DIR}/${PROJECT_NAME}${PROJECT_SUFFIX}-${PROJECT_VERSION} &&
         chmod u+w . _build _inst &&

--- a/distcheck.cmake
+++ b/distcheck.cmake
@@ -71,73 +71,88 @@ macro(DISTCHECK_SETUP)
     if(NOT TARGET distcheck)
       add_custom_target(distcheck COMMENT "Checking generated tarball...")
     endif()
+    # gersemi: off
     add_custom_target(
       ${PROJECT_NAME}-distcheck
       COMMAND
-        export LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH} && export
-        ${LD_LIBRARY_PATH_VARIABLE_NAME}=$ENV{${LD_LIBRARY_PATH_VARIABLE_NAME}}
-        && export PYTHONPATH=$ENV{PYTHONPATH} && find . -type d -print0 | xargs
-        -0 chmod a-w && chmod u+w . && rm -rf _build _inst && mkdir -p _build &&
-        mkdir -p _inst && chmod u+rwx _build _inst && chmod a-w . && cp
-        ${CMAKE_BINARY_DIR}/CMakeCache.txt _build/ && ${SED} ${SED_I_OPTION} -e
-        "'s|${CMAKE_SOURCE_DIR}|${SRCDIR}|g'" _build/CMakeCache.txt # Change
-        # previous
-        # source dir
-        # to the
-        # source one
-        && ${SED} ${SED_I_OPTION} -e "'s|${NEW_CMAKE_BINARY_DIR}|${BUILDDIR}|g'"
-        _build/CMakeCache.txt # Change previous binary dir by the current _build
-        # one
-        && ${SED} ${SED_I_OPTION} -e "'s|CMAKE_CXX_COMPILER:FILEPATH=.\\+||g'"
-        -e "'s|CMAKE_CXX_FLAGS:STRING=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS_DEBUG:STRING=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS_MINSIZEREL:STRING=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS_RELEASE:STRING=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=.\\+||g'" -e
-        "'s|CMAKE_CXX_COMPILER-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_CXX_COMPILER_WORKS:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS_DEBUG-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS_MINSIZEREL-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS_RELEASE-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_CXX_FLAGS_RELWITHDEBINFO-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_DETERMINE_CXX_ABI_COMPILED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_C_COMPILER:FILEPATH=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS:STRING=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS_DEBUG:STRING=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS_MINSIZEREL:STRING=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS_RELEASE:STRING=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS_RELWITHDEBINFO:STRING=.\\+||g'" -e
-        "'s|CMAKE_C_COMPILER-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS_DEBUG-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS_MINSIZEREL-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS_RELEASE-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_C_FLAGS_RELWITHDEBINFO-ADVANCED:INTERNAL=.\\+||g'" -e
-        "'s|CMAKE_DETERMINE_C_ABI_COMPILED:INTERNAL=.\\+||g'"
-        _build/CMakeCache.txt && cd _build && cmake
-        -DCMAKE_INSTALL_PREFIX=${INSTDIR}
-        -DCATKIN_TEST_RESULTS_DIR=${TEST_RESULTS_DIR} .. || cmake .. ||
-        (echo "ERROR: the cmake configuration failed." && false) && make
-        ${DISTCHECK_MAKEFLAGS} ||
-        (echo "ERROR: the compilation failed." && false) && make test ||
-        (echo "ERROR: the test suite failed." && false) && make install ||
-        (echo "ERROR: the install target failed." && false) && make uninstall ||
-        (echo "ERROR: the uninstall target failed." && false) && test `find
-        ${INSTDIR} -type f | wc -l` -eq 0 ||
-        (echo "ERROR: the uninstall target does not work." && false) && make
-        clean || (echo "ERROR: the clean target failed." && false) && cd
-        ${CMAKE_BINARY_DIR}/${PROJECT_NAME}${PROJECT_SUFFIX}-${PROJECT_VERSION}
-        && chmod u+w . _build _inst && rm -rf _build _inst && find . -type d
-        -print0 | xargs -0 chmod u+w && echo
-        "==============================================================" && echo
-        "${PROJECT_NAME}${PROJECT_SUFFIX}-${PROJECT_VERSION}"
-        "is ready for distribution." && echo
-        "=============================================================="
+        export LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH} &&
+        export ${LD_LIBRARY_PATH_VARIABLE_NAME}=$ENV{${LD_LIBRARY_PATH_VARIABLE_NAME}} &&
+        export PYTHONPATH=$ENV{PYTHONPATH} &&
+        find . -type d -print0 | xargs -0 chmod a-w &&
+        chmod u+w . &&
+        rm -rf _build _inst &&
+        mkdir -p _build &&
+        mkdir -p _inst &&
+        chmod u+rwx _build _inst &&
+        chmod a-w . &&
+        cp ${CMAKE_BINARY_DIR}/CMakeCache.txt _build/ &&
+        # Change previous source dir to the source one
+        ${SED} ${SED_I_OPTION} -e "'s|${CMAKE_SOURCE_DIR}|${SRCDIR}|g'" _build/CMakeCache.txt &&
+        # Change previous binary dir by the current _build one
+        ${SED} ${SED_I_OPTION} -e "'s|${NEW_CMAKE_BINARY_DIR}|${BUILDDIR}|g'" _build/CMakeCache.txt &&
+        ${SED} ${SED_I_OPTION}
+          -e "'s|CMAKE_CXX_COMPILER:FILEPATH=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS:STRING=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS_DEBUG:STRING=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS_MINSIZEREL:STRING=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS_RELEASE:STRING=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=.\\+||g'"
+          -e "'s|CMAKE_CXX_COMPILER-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_CXX_COMPILER_WORKS:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS_DEBUG-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS_MINSIZEREL-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS_RELEASE-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_CXX_FLAGS_RELWITHDEBINFO-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_DETERMINE_CXX_ABI_COMPILED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_C_COMPILER:FILEPATH=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS:STRING=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS_DEBUG:STRING=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS_MINSIZEREL:STRING=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS_RELEASE:STRING=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS_RELWITHDEBINFO:STRING=.\\+||g'"
+          -e "'s|CMAKE_C_COMPILER-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS_DEBUG-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS_MINSIZEREL-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS_RELEASE-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_C_FLAGS_RELWITHDEBINFO-ADVANCED:INTERNAL=.\\+||g'"
+          -e "'s|CMAKE_DETERMINE_C_ABI_COMPILED:INTERNAL=.\\+||g'"
+          _build/CMakeCache.txt &&
+        cd _build &&
+        cmake -DCMAKE_INSTALL_PREFIX=${INSTDIR} -DCATKIN_TEST_RESULTS_DIR=${TEST_RESULTS_DIR} .. ||
+          cmake .. ||
+          (echo "ERROR: the cmake configuration failed." && false)
+          &&
+        make ${DISTCHECK_MAKEFLAGS} ||
+          (echo "ERROR: the compilation failed." && false)
+          &&
+        make test ||
+          (echo "ERROR: the test suite failed." && false)
+          &&
+        make install ||
+          (echo "ERROR: the install target failed." && false)
+          &&
+        make uninstall ||
+          (echo "ERROR: the uninstall target failed." && false)
+          &&
+        test `find ${INSTDIR} -type f | wc -l` -eq 0 ||
+          (echo "ERROR: the uninstall target does not work." && false)
+          &&
+        make clean || (echo "ERROR: the clean target failed." && false)
+          &&
+        cd ${CMAKE_BINARY_DIR}/${PROJECT_NAME}${PROJECT_SUFFIX}-${PROJECT_VERSION} &&
+        chmod u+w . _build _inst &&
+        rm -rf _build _inst &&
+        find . -type d -print0 | xargs -0 chmod u+w &&
+        echo "==============================================================" &&
+        echo "${PROJECT_NAME}${PROJECT_SUFFIX}-${PROJECT_VERSION} is ready for distribution." &&
+        echo "=============================================================="
       WORKING_DIRECTORY
         ${CMAKE_BINARY_DIR}/${PROJECT_NAME}${PROJECT_SUFFIX}-${PROJECT_VERSION}
       COMMENT "Checking generated tarball..."
     )
+    # gersemi: on
     add_dependencies(distcheck ${PROJECT_NAME}-distcheck)
     add_dependencies(${PROJECT_NAME}-distcheck ${PROJECT_NAME}-distdir)
 


### PR DESCRIPTION
This PR add two orthogonal features:

- Allow to use ninja for the distcheck target (and then, the release target)
- Allow to call distcheck from a Pixi environment