### PR TITLE
Use c++11 attribute when C++11 is activated

### DIFF
--- a/config.hh.cmake
+++ b/config.hh.cmake
@@ -50,13 +50,23 @@
 # else
 // On Linux, for GCC >= 4, tag symbols using GCC extension.
 #  if __GNUC__ >= 4
-#   define @LIBRARY_NAME@_DLLIMPORT __attribute__ ((visibility("default")))
-#   define @LIBRARY_NAME@_DLLEXPORT __attribute__ ((visibility("default")))
-#   define @LIBRARY_NAME@_DLLLOCAL  __attribute__ ((visibility("hidden")))
-#   define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLIMPORT __attribute__ ((visibility("default")))
-#   define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLEXPORT __attribute__ ((visibility("default")))
-#   define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLIMPORT
-#   define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLEXPORT
+#   if defined(__cplusplus) && (__cplusplus >= 201103L)
+#    define @LIBRARY_NAME@_DLLIMPORT [[gnu::visibility("default")]]
+#    define @LIBRARY_NAME@_DLLEXPORT [[gnu::visibility("default")]]
+#    define @LIBRARY_NAME@_DLLLOCAL  [[gnu::visibility("hidden")]]
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLIMPORT [[gnu::visibility("default")]]
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLEXPORT [[gnu::visibility("default")]]
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLIMPORT
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLEXPORT
+#   else
+#    define @LIBRARY_NAME@_DLLIMPORT __attribute__ ((visibility("default")))
+#    define @LIBRARY_NAME@_DLLEXPORT __attribute__ ((visibility("default")))
+#    define @LIBRARY_NAME@_DLLLOCAL  __attribute__ ((visibility("hidden")))
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLIMPORT __attribute__ ((visibility("default")))
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLEXPORT __attribute__ ((visibility("default")))
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLIMPORT
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLEXPORT
+#   endif
 #  else
 // Otherwise (GCC < 4 or another compiler is used), export everything.
 #   define @LIBRARY_NAME@_DLLIMPORT

--- a/config.hh.cmake
+++ b/config.hh.cmake
@@ -50,6 +50,8 @@
 # else
 // On Linux, for GCC >= 4, tag symbols using GCC extension.
 #  if __GNUC__ >= 4
+// Use C++11 attribute if avaiable.
+// This avoid issue when mixing old and C++11 attributes with GCC < 13
 #   if defined(__cplusplus) && (__cplusplus >= 201103L)
 #    define @LIBRARY_NAME@_DLLIMPORT [[gnu::visibility("default")]]
 #    define @LIBRARY_NAME@_DLLEXPORT [[gnu::visibility("default")]]

--- a/config.hh.cmake
+++ b/config.hh.cmake
@@ -56,8 +56,9 @@
 #    define @LIBRARY_NAME@_DLLIMPORT [[gnu::visibility("default")]]
 #    define @LIBRARY_NAME@_DLLEXPORT [[gnu::visibility("default")]]
 #    define @LIBRARY_NAME@_DLLLOCAL  [[gnu::visibility("hidden")]]
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLIMPORT [[gnu::visibility("default")]]
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLEXPORT [[gnu::visibility("default")]]
+// gnu::visibility is not working with clang and explicit template instantiation
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLIMPORT __attribute__ ((visibility("default")))
+#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLEXPORT __attribute__ ((visibility("default")))
 #    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLIMPORT
 #    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLEXPORT
 #   else


### PR DESCRIPTION
With gcc < 13, mixing old `__attribute__` keyword and C++11 `[[ ]]` attribute can create some error.

To reproduce, we can compile the following code snippet on godbot:

```cpp
class [[gnu::visibility ("default")]] [[deprecated]] SomeClass1
{};

class [[gnu::visibility ("default"), deprecated]] SomeClass2
{};

class __attribute__((visibility ("default")))  __attribute__((deprecated)) SomeClass3
{};

class __attribute__((visibility ("default"))) [[deprecated]] SomeClass4
{};

int main()
{
    SomeClass1 c1;
    SomeClass2 c2;
    SomeClass3 c3;
    SomeClass4 c4;
}
```

`SomeClass4` will not compile on gcc < 13 with the following error:

```
<source>:10:47: error: expected identifier before '[' token
   10 | class __attribute__((visibility ("default"))) [[deprecated]] SomeClass4
```

This code build well with clang >= 3.0 when `-std=c++11` is activated.
If we remove SomeClass4 and deprecated attribute. This code build with gcc >= 4.8 when `-std=c++11` is activated.
deprecated attribute is working fine in gcc >= 5.

bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96117