### PR TITLE
Revert "Use c++11 attribute when C++11 is activated"

### DIFF
--- a/config.hh.cmake
+++ b/config.hh.cmake
@@ -50,26 +50,13 @@
 # else
 // On Linux, for GCC >= 4, tag symbols using GCC extension.
 #  if __GNUC__ >= 4
-// Use C++11 attribute if avaiable.
-// This avoid issue when mixing old and C++11 attributes with GCC < 13
-#   if defined(__cplusplus) && (__cplusplus >= 201103L)
-#    define @LIBRARY_NAME@_DLLIMPORT [[gnu::visibility("default")]]
-#    define @LIBRARY_NAME@_DLLEXPORT [[gnu::visibility("default")]]
-#    define @LIBRARY_NAME@_DLLLOCAL  [[gnu::visibility("hidden")]]
-// gnu::visibility is not working with clang and explicit template instantiation
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLIMPORT __attribute__ ((visibility("default")))
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLEXPORT __attribute__ ((visibility("default")))
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLIMPORT
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLEXPORT
-#   else
-#    define @LIBRARY_NAME@_DLLIMPORT __attribute__ ((visibility("default")))
-#    define @LIBRARY_NAME@_DLLEXPORT __attribute__ ((visibility("default")))
-#    define @LIBRARY_NAME@_DLLLOCAL  __attribute__ ((visibility("hidden")))
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLIMPORT __attribute__ ((visibility("default")))
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLEXPORT __attribute__ ((visibility("default")))
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLIMPORT
-#    define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLEXPORT
-#   endif
+#   define @LIBRARY_NAME@_DLLIMPORT __attribute__ ((visibility("default")))
+#   define @LIBRARY_NAME@_DLLEXPORT __attribute__ ((visibility("default")))
+#   define @LIBRARY_NAME@_DLLLOCAL  __attribute__ ((visibility("hidden")))
+#   define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLIMPORT __attribute__ ((visibility("default")))
+#   define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DECLARATION_DLLEXPORT __attribute__ ((visibility("default")))
+#   define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLIMPORT
+#   define @LIBRARY_NAME@_EXPLICIT_INSTANTIATION_DEFINITION_DLLEXPORT
 #  else
 // Otherwise (GCC < 4 or another compiler is used), export everything.
 #   define @LIBRARY_NAME@_DLLIMPORT


### PR DESCRIPTION
Reverts jrl-umi3218/jrl-cmakemodules#725

[[gnu::visibility]] is not working well for global variable:

```cpp
extern [[gnu::visibility("default")]] int GLOBAL; // not working
extern __attribute__((visibility("default"))) int GLOBAL; // working
```

So I revert it to avoid compatibility issue.
We finally found another solution in https://github.com/stack-of-tasks/pinocchio/pull/2469
