### PR TITLE
enable PYTHON_STANDARD_LAYOUT by default

### DIFF
--- a/python.cmake
+++ b/python.cmake
@@ -297,7 +297,7 @@ macro(FINDPYTHON)
     # directory
     option(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
     # ref. https://docs.python.org/3/library/site.html
-    option(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" OFF)
+    option(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" ON)
 
     if(PYTHON_STANDARD_LAYOUT)
       set(


### PR DESCRIPTION
Hi,

This is a breaking change, but I think it is worth it. Looking at our current usage, I can see this standard layout being used everywhere:

- arch: `/usr/lib/python3.13/site-packages/eigenpy/__init__.py`
- brew: `/opt/homebrew/lib/python3.13/site-packages/eigenpy/__init__.py`
- conda: `/opt/conda/lib/python3.12/site-packages/eigenpy/__init__.py`
- nix: `/nix/store/as3k32q45valgjl97sfsz5z1y4ylhfrs-python3-3.13.1-env/lib/python3.13/site-packages/eigenpy/__init__.py`
- pip: `/usr/local/lib/python3.13/site-packages/cmeel.prefix/lib/python3.13/site-packages/eigenpy/__init__.py`
- robotpkg: `/opt/openrobots/lib/python3.10/site-packages/eigenpy/__init__.py`
- ros: `/opt/ros/humble/lib/python3.10/site-packages/eigenpy/__init__.py`


The initial idea for turning this OFF was that when using what was standard at some point `cmake / make / sudo make install`, on debian/ubuntu systems, we would need to install in `/usr/local/lib/python3/dist-packages` to get things work out of the box; but that `sudo make install` is no longer advised.

The only problematic case I can see is with containers:
```Dockerfile
FROM ubuntu:noble

RUN apt-get update -y \
 && DEBIAN_FRONTEND=noninteractive apt-get install -y \
    build-essential \
    cmake \
    git \
    libboost-all-dev \
    libeigen3-dev \
    python3-numpy \
    python3-scipy \
    python-is-python3 \
 && rm -rf /var/lib/apt/lists/*

ARG EIGENPY=3.10.1

ADD https://github.com/stack-of-tasks/eigenpy/releases/download/v${EIGENPY}/eigenpy-${EIGENPY}.tar.gz /
RUN tar xf /eigenpy-${EIGENPY}.tar.gz

RUN cmake -B build -S /eigenpy-${EIGENPY}
RUN cmake --build build -j16
RUN cmake --build build -t test
RUN cmake --build build -t install
RUN python -c "import eigenpy"
```

In that particular cases, users will need to add `-DPYTHON_DEB_LAYOUT=ON` following this PR, or use and configure another installation prefix.

My main motivation here is ROS buildfarm, where we have to patch all our packages for all ROS versions with eg. https://github.com/ros2-gbp/eigenpy-release/blob/patches/release/humble/eigenpy/0002-ROS2-Set-PYTHON_DEB_LAYOUT-and-PYTHON_STANDARD_LAYOU.patch and maintain those patches, which is really not that easy because of the gbp workflow used by ROS. Also, testing the release of ROS packages is impossible since https://prerelease.ros.org/ is dead, and this kind of errors is not found by ros-industrial CI. So we need to blindly open a PR on ros/rodistro, wait for it to be merged, and then wait for the next buildfarm rebuild before we can detect this kind of error.