### PR TITLE
distcheck: recursively restore user write permissions

### DIFF
--- a/distcheck.cmake
+++ b/distcheck.cmake
@@ -145,7 +145,7 @@ macro(DISTCHECK_SETUP)
         ${BUILD_CMD} clean || (echo "ERROR: the clean target failed." && false)
           &&
         cd ${CMAKE_BINARY_DIR}/${PROJECT_NAME}${PROJECT_SUFFIX}-${PROJECT_VERSION} &&
-        chmod u+w . _build _inst &&
+        chmod u+w -R . _build _inst &&
         rm -rf _build _inst &&
         find . -type d -print0 | xargs -0 chmod u+w &&
         echo "==============================================================" &&


### PR DESCRIPTION
This PR fixes a possible bug (which I've just encountered) when performing the `rm -rf _build _inst` on line 148 of `distcheck.cmake`.

The bug stems from the fact that the `chmod` on the previous line is not recursive, although the `chmod a-w` on line 88 seems to be recursive? Not sure why it's asymmetrical.