### PR TITLE
Tells Clang to pass -fopenmp to the preprocessor rather than frontend

### DIFF
--- a/find-external/OpenMP/FindOpenMP.cmake
+++ b/find-external/OpenMP/FindOpenMP.cmake
@@ -103,9 +103,9 @@ function(_OPENMP_FLAG_CANDIDATES LANG)
       "-fopenmp=libomp"
       "-fopenmp=libiomp5"
       "-fopenmp"
-      "-Xclang -fopenmp"
+      "-Xpreprocessor -fopenmp"
     )
-    set(OMP_FLAG_AppleClang "-Xclang -fopenmp")
+    set(OMP_FLAG_AppleClang "-Xpreprocessor -fopenmp")
     set(OMP_FLAG_HP "+Oopenmp")
     if(WIN32)
       set(OMP_FLAG_Intel "-Qopenmp")


### PR DESCRIPTION
Hi folks,

I believe we should use -Xpreprocessor rather than -Xclang. Please let me know your thoughts. I am unaware of the reasons why cmake is -Xclang.

Thanks,

