### PR TITLE
doxygen: fix install of doxytag

### DIFF
--- a/github/update-doxygen-doc.sh
+++ b/github/update-doxygen-doc.sh
@@ -307,7 +307,7 @@ cd ${tmp}/project \
 echo "* Copy the documentation..."
 git rm --quiet -rf doxygen/${doc_version} || true
 mkdir -p doxygen/${doc_version}
-cp -rf ${build_dir}/doc/doxygen-html/* ${build_dir}/doc/*.doxytag doxygen/${doc_version}/ \
+cp -rf ${build_dir}/doc/doxygen-html/* doxygen/${doc_version}/ \
  || abort "failed to copy the documentation"
 
 echo "* Fixing cross links..."


### PR DESCRIPTION
Commit 1707f20 modified the build-tree location of .doxytag file, but the `update-doxygen-doc.sh` still expects the former location.