### PR TITLE
Update jrl_print_banner and cache git commit info

### DIFF
--- a/v2/modules/jrl.cmake
+++ b/v2/modules/jrl.cmake
@@ -549,10 +549,16 @@ message(STATUS "jrl-cmakemodules commit: ${commit}")
 ```
 #]============================================================================]
 function(jrl_cmakemodules_get_commit output_var)
+    if(DEFINED CACHE{_JRL_COMMIT})
+        set(${output_var} "${_JRL_COMMIT}" PARENT_SCOPE)
+        return()
+    endif()
+
     find_program(GIT git QUIET)
 
     if(NOT GIT)
         message(DEBUG "Git executable not found, cannot get jrl-cmakemodules commit hash.")
+        set(_JRL_COMMIT "" CACHE INTERNAL "Cached commit hash of jrl-cmakemodules")
         return()
     endif()
 
@@ -567,10 +573,12 @@ function(jrl_cmakemodules_get_commit output_var)
     # It might not be a git repository (e.g. downloaded zip archive)
     if(NOT git_commit)
         message(DEBUG "Could not get jrl-cmakemodules commit hash.")
+        set(_JRL_COMMIT "" CACHE INTERNAL "Cached commit hash of jrl-cmakemodules")
         return()
     endif()
 
-    set(${output_var} ${git_commit} PARENT_SCOPE)
+    set(_JRL_COMMIT "${git_commit}" CACHE INTERNAL "Cached commit hash of jrl-cmakemodules")
+    set(${output_var} "${git_commit}" PARENT_SCOPE)
 endfunction()
 
 #[============================================================================[

--- a/v2/modules/jrl.cmake
+++ b/v2/modules/jrl.cmake
@@ -613,11 +613,8 @@ function(jrl_print_banner)
 
     message(
         STATUS
-        "
-        🚧 Welcome to JRL CMake Modules v${v} ${commit_msg}
-        🚧 Loaded from: ${CMAKE_CURRENT_FUNCTION_LIST_FILE}
-        🚧 This v2 API is still under heavy development.
-        🚧 API may change without notice.
+        "JRL CMake Modules v${v} ${commit_msg}
+   Loaded from: ${CMAKE_CURRENT_FUNCTION_LIST_FILE}
     "
     )
 endfunction()


### PR DESCRIPTION
* shorten and remove emoji (its release time!)
* cache the commit to prevent calling git all the time - slow on windows.