### PR TITLE
v2(nix): add jrl-release tool

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,67 @@
     inputs.gepetto.lib.mkFlakoboros inputs (
       { lib, ... }:
       {
+        pyPackages.cmake-parser =
+          {
+            buildPythonPackage,
+            setuptools,
+            setuptools-scm,
+            fetchPypi,
+            attrs,
+            ...
+          }:
+          buildPythonPackage rec {
+            pname = "cmake_parser";
+            version = "0.9.2";
+            pyproject = true;
+
+            build-system = [
+              setuptools
+              setuptools-scm
+            ];
+            dependencies = [ attrs ];
+
+            src = fetchPypi {
+              inherit pname version;
+              hash = "sha256-t6MT0/QeWMCeCIbyyY8/zuKxiX/n+HRJgjpT5RqyOj0=";
+            };
+          };
+
+        pyPackages.jrl-release =
+          {
+            buildPythonPackage,
+            cmake-parser,
+            uv-build,
+            setuptools,
+            tomlkit,
+            ruamel-yaml,
+            rich,
+            packaging,
+            ...
+          }:
+          buildPythonPackage {
+            inherit ((lib.importTOML ./v2/scripts/pyproject.toml).project) name version;
+            pyproject = true;
+
+            src = lib.cleanSource ./v2/scripts;
+
+            build-system = [
+              uv-build
+              setuptools
+            ];
+
+            dependencies = [
+              tomlkit
+              ruamel-yaml
+              rich
+              packaging
+              cmake-parser
+            ];
+            meta = {
+              mainProgram = "jrl-release";
+            };
+          };
+
         overrideAttrs.jrl-cmakemodules =
           { pkgs-final, ... }:
           {


### PR DESCRIPTION
@nim65s I'm not yet used to package pure python applications, so not sure this is the best nix-way of doing it (it works). 
Also, I'm confused where the "upstream" `jrl-cmakemodule` package is, directly on nixos/nixpkgs? Should I upstream the cmake-parser derivation?