### PR TITLE
jrl_release: Add DebianChangelogVersionExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- jrl_release: add `DebianChangelogVersionExtractor` by @arntanguy
+
 ## [2.1.0] - 2026-07-03
 
 - jrl_release: add `--sign-tag` to sign the tag by @ahoarau

--- a/v2/scripts/jrl_release.py
+++ b/v2/scripts/jrl_release.py
@@ -372,6 +372,114 @@ class CMakeListsVersionExtractor(VersionExtractor):
             f.write(content)
 
 
+class DebianChangelogVersionExtractor(VersionExtractor):
+    """Specialized extractor for debian/changelog files.
+
+    Expects standard format: package (version) distribution; urgency=...
+    """
+
+    @property
+    def name(self) -> str:
+        return "debian/changelog"
+
+    def get_version(self) -> str:
+        """Extracts and returns the clean upstream version string (omitting the Debian suffix)."""
+        with open(self.file_path, "r", encoding="utf-8") as f:
+            first_line = f.readline()
+
+        if not first_line:
+            raise VersionNotPresent(f"Changelog file {self.name} is empty")
+
+        match = re.match(r"^[a-zA-Z0-9.+_-]+\s+\(([^)]+)\)", first_line)
+        if match:
+            full_version = match.group(1)
+            # Splits on '-' or '~' to strip the packaging revision (e.g., '1.3.3-1debian1' -> '1.3.3')
+            return re.split(r"[-~]", full_version)[0]
+
+        raise VersionNotPresent(
+            f"Could not parse Debian version from first line of {self.name}"
+        )
+
+    def _get_raw_full_version(self) -> str:
+        """Internal helper to get the un-stripped full version string with its suffix."""
+        with open(self.file_path, "r", encoding="utf-8") as f:
+            first_line = f.readline()
+        match = re.match(r"^[a-zA-Z0-9.+_-]+\s+\(([^)]+)\)", first_line)
+        return match.group(1) if match else ""
+
+    def update_version(self, new_version: str) -> None:
+        # Compare core upstream versions safely to avoid duplicate entries
+        try:
+            if self.get_version() == re.split(r"[-~]", new_version)[0]:
+                return  # Skip adding a duplicate entry
+        except VersionNotPresent:
+            pass
+
+        # Grab the raw full version string to parse its suffix before reading full file
+        try:
+            current_full_version = self._get_raw_full_version()
+        except Exception:
+            current_full_version = ""
+
+        with open(self.file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Parse the first line to reuse metadata
+        first_line = content.splitlines()[0] if content.strip() else ""
+        match = re.match(
+            r"^([a-zA-Z0-9.+_-]+)\s+\([^)]+\)\s+([^;]+);\s*(urgency=\w+)",
+            first_line,
+        )
+
+        if match:
+            package_name = match.group(1)
+            distribution = match.group(2).strip()
+            urgency = match.group(3)
+        else:
+            package_name = "package"
+            distribution = "unstable"
+            urgency = "urgency=medium"
+
+        # Determine the final version string to write, preserving the suffix
+        new_upstream = re.split(r"[-~]", new_version)[0]
+        if "-" in new_version or "~" in new_version:
+            formatted_version = new_version
+        elif current_full_version and (
+            "-" in current_full_version or "~" in current_full_version
+        ):
+            suffix_match = re.search(r"([-~].*)$", current_full_version)
+            suffix = suffix_match.group(1) if suffix_match else "-1"
+            formatted_version = f"{new_upstream}{suffix}"
+        else:
+            formatted_version = f"{new_upstream}-1"
+
+        # Fetch maintainer details
+        repo_dir = self.file_path.parent
+        name_ok, git_name = run_git_command(["config", "user.name"], cwd=repo_dir)
+        email_ok, git_email = run_git_command(["config", "user.email"], cwd=repo_dir)
+
+        if name_ok and email_ok:
+            maintainer = f"{git_name} <{git_email}>"
+        else:
+            maintainer = "Maintainer <maintainer@example.com>"
+
+        # Format RFC 5322 timestamp
+        now = datetime.datetime.now(datetime.timezone.utc).astimezone()
+        debian_date = now.strftime("%a, %d %b %Y %H:%M:%S %z")
+
+        # Write out using the compliant version with the preserved suffix
+        new_entry = (
+            f"{package_name} ({formatted_version}) {distribution}; {urgency}\n\n"
+            f"  * New release: version {new_upstream}\n\n"
+            f" -- {maintainer}  {debian_date}\n\n"
+        )
+
+        updated_content = new_entry + content
+
+        with open(self.file_path, "w", encoding="utf-8") as f:
+            f.write(updated_content)
+
+
 class ChangelogVersionExtractor(VersionExtractor):
     def __init__(self, file_path: Path, pattern: str = ""):
         super().__init__(file_path)
@@ -1226,6 +1334,7 @@ def main():
         TomlVersionExtractor(root_dir / "pixi.toml", ["workspace", "version"]),
         YamlVersionExtractor(root_dir / "CITATION.cff", ["version"]),
         CMakeListsVersionExtractor(root_dir / "CMakeLists.txt"),
+        DebianChangelogVersionExtractor(root_dir / "debian/changelog"),
     ]
 
     if args.list_files:

--- a/v2/scripts/test_jrl_release.py
+++ b/v2/scripts/test_jrl_release.py
@@ -557,6 +557,108 @@ add_library(mylib src/lib.cpp)
 
 
 # ============================================================================
+# TEST DebianChangelogVersionExtractor
+# ============================================================================
+
+
+# A simple mock function that matches the signature of jrl_release's real run_git_command
+# This is used to monkeypatch the jrl_release module to ensure environment repeatability
+def mock_run_git_command(args, cwd):
+    if "user.name" in args:
+        return True, "Jane Doe"
+    if "user.email" in args:
+        return True, "jane.doe@example.com"
+    return False, ""
+
+
+def test_debian_extractor_get_version_strips_suffix(tmp_path):
+    """Test that get_version successfully extracts only the upstream version part."""
+    content = """my-package (1.3.3-1debian1) unstable; urgency=medium
+
+  * Bug fixes.
+
+ -- Maintainer <maintainer@example.com>  Sat, 04 Jul 2026 12:00:00 +0200
+"""
+    file_path = tmp_path / "changelog"
+    file_path.write_text(content, encoding="utf-8")
+
+    extractor = release.DebianChangelogVersionExtractor(file_path)
+
+    # Should cleanly return just the core upstream version
+    assert extractor.get_version() == "1.3.3"
+
+
+def test_debian_extractor_update_version_preserves_suffix(tmp_path, monkeypatch):
+    """Test updating the version creates a new block while maintaining the exact custom debian suffix."""
+    # Use mock run_git_command to ensure environment repeatability
+    monkeypatch.setattr("jrl_release.run_git_command", mock_run_git_command)
+
+    content = """my-package (1.3.2-1debian1) unstable; urgency=medium
+
+  * Previous release.
+
+ -- Jane Doe <jane.doe@example.com>  Fri, 03 Jul 2026 12:00:00 +0200
+"""
+    file_path = tmp_path / "changelog"
+    file_path.write_text(content, encoding="utf-8")
+
+    extractor = release.DebianChangelogVersionExtractor(file_path)
+    extractor.update_version("1.3.3")
+
+    updated_content = file_path.read_text(encoding="utf-8")
+
+    # Verify the new top entry structure and version serialization
+    assert updated_content.startswith(
+        "my-package (1.3.3-1debian1) unstable; urgency=medium"
+    )
+    assert "Jane Doe <jane.doe@example.com>" in updated_content
+    assert "my-package (1.3.2-1debian1)" in updated_content
+
+
+def test_debian_extractor_update_version_no_duplicate(tmp_path):
+    """Test that update_version exits early if the core upstream version is already current."""
+    content = """my-package (1.3.3-1debian1) unstable; urgency=medium
+
+  * Current release.
+
+ -- Jane Doe <jane.doe@example.com>  Sat, 04 Jul 2026 12:00:00 +0200
+"""
+    file_path = tmp_path / "changelog"
+    file_path.write_text(content, encoding="utf-8")
+
+    extractor = release.DebianChangelogVersionExtractor(file_path)
+    extractor.update_version("1.3.3")
+
+    updated_content = file_path.read_text(encoding="utf-8")
+
+    # Count occurrences; should not append a duplicate block since 1.3.3 is already live
+    assert updated_content.count("my-package") == 1
+
+
+def test_debian_extractor_update_explicit_suffix_provided(tmp_path, monkeypatch):
+    """Test that if a specific suffix is intentionally passed inside new_version, it overrides the old suffix."""
+    # Use mock run_git_command to ensure environment repeatability
+    monkeypatch.setattr("jrl_release.run_git_command", mock_run_git_command)
+
+    content = """my-package (1.3.2-1debian1) unstable; urgency=medium
+
+  * Previous release.
+
+ -- Jane Doe <jane.doe@example.com>  Fri, 03 Jul 2026 12:00:00 +0200
+"""
+    file_path = tmp_path / "changelog"
+    file_path.write_text(content, encoding="utf-8")
+
+    extractor = release.DebianChangelogVersionExtractor(file_path)
+    extractor.update_version("1.4.0-0ubuntu1")
+
+    updated_content = file_path.read_text(encoding="utf-8")
+    assert updated_content.startswith(
+        "my-package (1.4.0-0ubuntu1) unstable; urgency=medium"
+    )
+
+
+# ============================================================================
 # TEST ChangelogVersionExtractor
 # ============================================================================
 


### PR DESCRIPTION
@ahoarau In JRL/LIRMM ecosystem, we have debian packaging handled by each repository with a `debian/` folder containing all files expected by `debbuild` tools. We need to ensure that the `debian/changelog` versions remain synced with the project.

Ex: https://github.com/jrl-umi3218/copra/commit/7d4ecb29ec76762521e7991a0adb6ebc09403c57, the first entry was autogenerated by this PR.
```
copra (1.3.3-1debian1) unstable; urgency=medium

  * New release: version 1.3.3

 -- Arnaud TANGUY <arn.tanguy@gmail.com>  Sat, 04 Jul 2026 18:21:00 +0200

copra (1.3.2-1debian1) unstable; urgency=medium

  * Release 1.3.2

 -- Thomas Duvinage <t.duvinage+ppa@outlook.fr>  Wed, 23 Jul 2025 11:01:35 +0900
 ```

This:
- Adds a `DebianChangelogVersionExtractor`
- Gets the full version `1.3.2-1debian1`, the `-1debian1` is a version specific to debian packaging. In practice, I don't think we've ever bumped it, so I think it makes sense to just copy it from the previous version to the new one. If the case is more complex than this, we probably need to be doing some explicit packaging anyways.
- Bump the version number to `1.3.3-1debian1`. The `-1debian1` is a version specific to debian packaging. In practice, I don't think we've ever bumped it, so I think it makes sense to just copy it from the previous version to the new one. If the case is more complex than this, we probably need to be doing some explicit packaging anyways.
- Opinionated choice: The maintainer name and address is obtained from git. That's in line with the other commands that can do commits/tags for us. This has a small implications on tests: I used a monkeypatch to replace the `run_git_command` call with a dummy so that we always get the same user name/mail.
