### PR TITLE
jrl_release: support both PROJECT_VERSION "X.Y.Z" and X.Y.Z

### DIFF
--- a/v2/scripts/jrl_release.py
+++ b/v2/scripts/jrl_release.py
@@ -288,7 +288,7 @@ class CMakeListsVersionExtractor(VersionExtractor):
                                 ver = args[version_idx + 1]
                                 # Check if it's a variable reference
                                 if not ver.startswith("${"):
-                                    project_version = ver
+                                    project_version = ver.strip('"')
                         except ValueError:
                             pass
 
@@ -316,16 +316,16 @@ class CMakeListsVersionExtractor(VersionExtractor):
 
     def _get_version_regex(self, content: str) -> str:
         """Fallback regex-based version extraction."""
-        # First try to find set(PROJECT_VERSION "X.Y.Z")
+        # Finds set(PROJECT_VERSION "X.Y.Z") or set(PROJECT_VERSION X.Y.Z)
         fallback_pattern = re.compile(
-            r'set\s*\(\s*PROJECT_VERSION\s+"([0-9]+\.[0-9]+\.[0-9]+)"',
+            r'set\s*\(\s*PROJECT_VERSION\s+"?([0-9]+\.[0-9]+\.[0-9]+)"?\s*\)',
             re.MULTILINE,
         )
         fallback_match = fallback_pattern.search(content)
 
         # Also check if project() uses a literal version or variable
         project_pattern = re.compile(
-            r"project\s*\([^)]*VERSION\s+([\d.]+|\$\{[^}]+\})", re.MULTILINE
+            r'project\s*\([^)]*VERSION\s+"?([\d.]+|\$\{[^}]+\})"?', re.MULTILINE
         )
         project_match = project_pattern.search(content)
 
@@ -347,20 +347,22 @@ class CMakeListsVersionExtractor(VersionExtractor):
         with open(self.file_path, "r", encoding="utf-8") as f:
             content = f.read()
 
-        # Update the fallback version in set(PROJECT_VERSION "...")
+        # 1. Update fallback version: matches set(PROJECT_VERSION 1.2.3) or set(PROJECT_VERSION "1.2.3")
+        #    Always replaces it without quotes: set(PROJECT_VERSION 1.2.3)
         fallback_pattern = re.compile(
-            r'(set\s*\(\s*PROJECT_VERSION\s+)"([0-9]+\.[0-9]+\.[0-9]+)"',
+            r'(set\s*\(\s*PROJECT_VERSION\s+)"?([0-9]+\.[0-9]+\.[0-9]+)"?\s*\)',
             re.MULTILINE,
         )
 
         def repl_fallback(match):
-            return f'{match.group(1)}"{new_version}"'
+            return f"{match.group(1)}{new_version})"
 
         content = fallback_pattern.sub(repl_fallback, content, count=1)
 
-        # Also update literal version in project() if present
+        # 2. Update literal version in project(): matches VERSION 1.2.3 or VERSION "1.2.3"
+        #    Always replaces it without quotes: VERSION 1.2.3
         project_pattern = re.compile(
-            r"(project\s*\([^)]*VERSION\s+)([\d.]+)", re.MULTILINE
+            r'(project\s*\([^)]*VERSION\s+)"?([\d.]+)"?', re.MULTILINE
         )
 
         def repl_project(match):

--- a/v2/scripts/test_jrl_release.py
+++ b/v2/scripts/test_jrl_release.py
@@ -463,14 +463,15 @@ def test_cmake_extractor_update_version_simple(sample_cmake_lists):
     assert 'DESCRIPTION "A test project"' in content
 
 
-def test_cmake_extractor_update_version_multiline(tmp_path):
-    """Test CMakeListsVersionExtractor can update version in multiline project()."""
-    content = """cmake_minimum_required(VERSION 3.22)
+@pytest.mark.parametrize("version_format", ["1.0.0", '"1.0.0"'])
+def test_cmake_extractor_update_version_multiline(tmp_path, version_format):
+    """Test CMakeListsVersionExtractor can update version in multiline project() with and without quotes."""
+    content = f"""cmake_minimum_required(VERSION 3.22)
 
 project(
   TestProject
   DESCRIPTION "Test project"
-  VERSION 1.0.0
+  VERSION {version_format}
   LANGUAGES CXX
 )
 """
@@ -483,17 +484,19 @@ project(
     assert extractor.get_version() == "1.2.3"
     content = file_path.read_text(encoding="utf-8")
     assert "VERSION 1.2.3" in content
+    assert '"1.2.3"' not in content
 
 
-def test_cmake_extractor_update_fallback_version(tmp_path):
-    """Test CMakeListsVersionExtractor updates both fallback and project version."""
-    content = """cmake_minimum_required(VERSION 3.22)
+@pytest.mark.parametrize("version_format", ["1.0.0", '"1.0.0"'])
+def test_cmake_extractor_update_fallback_version(tmp_path, version_format):
+    """Test CMakeListsVersionExtractor updates both fallback and project version, ensuring quotes are dropped."""
+    content = f"""cmake_minimum_required(VERSION 3.22)
 
-set(PROJECT_VERSION "1.0.0")
+set(PROJECT_VERSION {version_format})
 
 project(
   TestProject
-  VERSION ${PROJECT_VERSION}
+  VERSION ${{PROJECT_VERSION}}
   LANGUAGES NONE
 )
 """
@@ -503,9 +506,10 @@ project(
     extractor = release.CMakeListsVersionExtractor(file_path)
     extractor.update_version("2.5.0")
 
-    # Check that fallback was updated
+    # Check that fallback was updated and has no quotes
     content = file_path.read_text(encoding="utf-8")
-    assert 'set(PROJECT_VERSION "2.5.0")' in content
+    assert "set(PROJECT_VERSION 2.5.0)" in content
+    assert '"2.5.0"' not in content
 
 
 def test_cmake_extractor_no_version_found(tmp_path):


### PR DESCRIPTION
Most of our projects use
```
set(PROJECT_VERSION X.Y.Z)
```
and not
```
set(PROJECT_VERSION "X.Y.Z")
```

Supports both, and always sets the unquoted result.