### PR TITLE
Fix documentation installation when working outside build directory

### DIFF
--- a/doxygen.cmake
+++ b/doxygen.cmake
@@ -589,7 +589,7 @@ macro(_SETUP_PROJECT_DOCUMENTATION)
       if(INSTALL_DOCUMENTATION)
         install(
           CODE
-            "EXECUTE_PROCESS(COMMAND ${CMAKE_MAKE_PROGRAM} ${PROJECT_NAME}-doc)"
+            "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target ${PROJECT_NAME}-doc)"
         )
       endif(INSTALL_DOCUMENTATION)
     endif(MSVC)

--- a/man.cmake
+++ b/man.cmake
@@ -43,7 +43,7 @@ macro(MANPAGE NAME)
   )
 
   # Trigger man page generation at install.
-  install(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_MAKE_PROGRAM} man)")
+  install(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target man)")
 
   # Detects if PKGMAN has been specified
   set(DESTINATION_MAN_PAGE share/man/man1)

--- a/sphinx.cmake
+++ b/sphinx.cmake
@@ -77,7 +77,7 @@ macro(SPHINX_SETUP)
 
       if(INSTALL_DOCUMENTATION)
         install(
-          CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_MAKE_PROGRAM} sphinx-doc)"
+          CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target sphinx-doc)"
         )
       endif(INSTALL_DOCUMENTATION)
     else() # UNIX
@@ -97,7 +97,7 @@ macro(SPHINX_SETUP)
 
       if(INSTALL_DOCUMENTATION)
         install(
-          CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_MAKE_PROGRAM} sphinx-doc)"
+          CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target sphinx-doc)"
         )
       endif(INSTALL_DOCUMENTATION)
     endif(MSVC)


### PR DESCRIPTION
When installing with `cmake --install build` we can have the following error:

```bash
ninja: error: loading 'build.ninja': No such file or directory
CMake Error at build/cmake_install.cmake:70 (file):
  file INSTALL cannot find "/tmp/pinocchio/build/doc/doxygen-html": No such
  file or directory.
```
To fix this we use `cmake --build` instead of generator make program so we can provide binary directory path as argument.