### PR TITLE
jrl_release: Meta pkg ros support

### DIFF
--- a/v2/scripts/jrl_release.py
+++ b/v2/scripts/jrl_release.py
@@ -73,10 +73,23 @@ uv run --no-project jrl_release.py --bump patch --git-commit --git-tag
 | `CMakeLists.txt` | `project(... VERSION X.Y.Z ...)` |
 
 > Requires `pixi` CLI if `pixi.lock` exists in the project root.
+
+## Meta-packages
+
+ROS meta-packages are handled automatically: every nested directory with a
+`package.xml` is treated like the repository root — the full set of
+supported files (`package.xml`, `pyproject.toml`, `CHANGELOG.md`, `pixi.toml`,
+`CITATION.cff`, `CMakeLists.txt`, `debian/changelog`) is checked there too,
+skipping any that don't exist in that nested directory.
+Discovery skips hidden directories (`.git`, `.pixi`, `.venv`, …), git submodules,
+and — honoring your `.gitignore` via `git check-ignore` — ignored dirs like
+`build/` or `dist/`. All discovered files must agree on a single
+version to bump version.
 """
 
 import sys
 import re
+import os
 import argparse
 import datetime
 import json
@@ -132,6 +145,8 @@ class VersionNotPresent(Exception):
 class VersionExtractor(ABC):
     def __init__(self, file_path: Path):
         self.file_path = file_path
+        # Display label; discovery overrides it with a root-relative path.
+        self.label = file_path.name
 
     @abstractmethod
     def get_version(self) -> str:
@@ -540,6 +555,204 @@ class ChangelogVersionExtractor(VersionExtractor):
         )
 
 
+def git_ignored_abs_dirs(repo_dir: Path) -> set:
+    """Absolute paths of git-ignored directories for the repo containing ``repo_dir``.
+
+    Runs ``git ls-files --directory`` from ``repo_dir`` so git resolves the
+    enclosing repository itself; paths are reported relative to ``repo_dir`` and
+    resolved to absolute Paths. Empty when ``repo_dir`` is not inside a repo.
+
+    Used to prune ignored dirs (e.g. build/, output/) during discovery instead
+    of walking into them.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "ls-files",
+                "--others",
+                "--ignored",
+                "--exclude-standard",
+                "--directory",
+                "-z",
+            ],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return set()
+
+    if result.returncode != 0:
+        return set()
+
+    return {
+        (repo_dir / entry.rstrip("/")).resolve()
+        for entry in result.stdout.split("\0")
+        if entry
+    }
+
+
+def drop_git_ignored(root_dir: Path, paths: List[Path]) -> List[Path]:
+    """Drop paths that git ignores, honoring each path's own enclosing repo.
+
+    Candidates may live in independent nested git repositories even when
+    ``root_dir`` is not itself a repo (e.g. a plain folder holding several
+    checkouts). Anchoring a single ``git check-ignore`` at ``root_dir`` would
+    then bail out entirely and leak ignored build trees like ``output/`` into
+    the results. Instead, resolve the repository that actually contains each
+    candidate and run ``git check-ignore`` there. Paths outside any repo are
+    always kept.
+    """
+    if not paths:
+        return paths
+
+    # Group candidates by the git repo top-level that contains them.
+    groups: Dict[Path, List[Path]] = {}
+    for p in paths:
+        ok, top = run_git_command(["rev-parse", "--show-toplevel"], p.parent)
+        if not ok or not top:
+            continue  # not inside any repo -> always kept
+        groups.setdefault(Path(top).resolve(), []).append(p)
+
+    ignored: set = set()
+    for top_path, repo_paths in groups.items():
+        rel = [str(p.resolve().relative_to(top_path)) for p in repo_paths]
+        try:
+            result = subprocess.run(
+                ["git", "check-ignore", "-z", "--stdin"],
+                cwd=top_path,
+                input="\0".join(rel) + "\0",
+                capture_output=True,
+                text=True,
+            )
+        except (FileNotFoundError, OSError):
+            continue  # keep this repo's candidates on git failure
+
+        # 0 = some ignored, 1 = none ignored; anything else is an error, keep all.
+        if result.returncode not in (0, 1):
+            continue
+
+        ignored_rel = {chunk for chunk in result.stdout.split("\0") if chunk}
+        ignored.update(p for p, r in zip(repo_paths, rel) if r in ignored_rel)
+
+    return [p for p in paths if p not in ignored]
+
+
+def git_submodule_dirs(root_dir: Path) -> set:
+    """Absolute paths of git submodule working trees (empty outside a git repo)."""
+    ok, top = run_git_command(["rev-parse", "--show-toplevel"], root_dir)
+    if not ok or not top:
+        return set()
+    top = Path(top)
+
+    ok, out = run_git_command(
+        ["config", "--file", ".gitmodules", "-z", "--get-regexp", "path"], top
+    )
+    if not ok or not out:
+        return set()
+
+    dirs = set()
+    for record in out.split("\0"):
+        key, _, value = record.partition("\n")
+        if key.endswith(".path") and value:
+            dirs.add((top / value).resolve())
+    return dirs
+
+
+def drop_submodules(root_dir: Path, paths: List[Path]) -> List[Path]:
+    """Drop paths inside git submodules (they are versioned independently)."""
+    if not paths:
+        return paths
+    subdirs = git_submodule_dirs(root_dir)
+    if not subdirs:
+        return paths
+    kept = []
+    for p in paths:
+        resolved = p.resolve()
+        if any(resolved == s or s in resolved.parents for s in subdirs):
+            continue
+        kept.append(p)
+    return kept
+
+
+def discover_package_roots(root_dir: Path) -> List[Path]:
+    """Discover nested ROS package roots (dirs with a package.xml, root excluded).
+
+    Skips hidden directories (.git, .pixi, ...), git submodules, and — inside a
+    git repo — anything git ignores (.gitignore, global excludes), like `fd`.
+
+    Hidden and ignored directories are pruned during the walk so we never
+    descend into large trees like `.venv` or `build/`. Nested repositories are
+    handled too: each one's ignore rules are learned when its top-level is
+    reached, so an ignored `output/` build tree is pruned even when `root_dir`
+    itself is not a git repo.
+    """
+    # Seed from root_dir's own repo (covers root being, or living inside, a repo).
+    ignored_abs = git_ignored_abs_dirs(root_dir)
+    candidates = []
+    for dirpath, dirnames, filenames in os.walk(root_dir):
+        current = Path(dirpath)
+        # A nested repo brings its own .gitignore; learn what it ignores before
+        # descending, so its build trees are pruned regardless of root_dir.
+        if current != root_dir and (current / ".git").exists():
+            ignored_abs |= git_ignored_abs_dirs(current)
+        kept = []
+        for d in dirnames:
+            if d.startswith("."):
+                continue
+            if ignored_abs and (current / d).resolve() in ignored_abs:
+                continue
+            kept.append(d)
+        dirnames[:] = kept
+        if current != root_dir and "package.xml" in filenames:
+            candidates.append(current / "package.xml")
+    candidates = drop_git_ignored(root_dir, candidates)
+    candidates = drop_submodules(root_dir, candidates)
+    return sorted({package_xml.parent for package_xml in candidates})
+
+
+def build_root_checks(root_dir: Path) -> List[VersionExtractor]:
+    """Build the version extractors tracked at the repository root."""
+    return [
+        XmlVersionExtractor(root_dir / "package.xml"),
+        TomlVersionExtractor(root_dir / "pyproject.toml", ["project", "version"]),
+        ChangelogVersionExtractor(root_dir / "CHANGELOG.md", r""),
+        TomlVersionExtractor(root_dir / "pixi.toml", ["workspace", "version"]),
+        YamlVersionExtractor(root_dir / "CITATION.cff", ["version"]),
+        CMakeListsVersionExtractor(root_dir / "CMakeLists.txt"),
+        DebianChangelogVersionExtractor(root_dir / "debian/changelog"),
+        ConanfileVersionExtractor(root_dir / "conanfile.py"),
+    ]
+
+
+def collect_version_checks(root_dir: Path) -> List[VersionExtractor]:
+    """Root checks plus the same set of checks for each nested package.
+
+    Each nested package is treated exactly like the repository root: the same
+    file/key combinations are checked, and any that don't exist in the nested
+    package directory are simply skipped (VersionExtractor.check_file_exists()).
+    """
+    checks = list(build_root_checks(root_dir))
+    seen_paths = {check.file_path for check in checks}
+
+    for package_root in discover_package_roots(root_dir):
+        for check in build_root_checks(package_root):
+            if check.file_path in seen_paths:
+                continue
+            checks.append(check)
+            seen_paths.add(check.file_path)
+
+    # Label nested files by their relative path so identical basenames stay distinct.
+    for check in checks:
+        try:
+            check.label = str(check.file_path.relative_to(root_dir))
+        except ValueError:
+            check.label = check.file_path.name
+
+    return checks
+
+
 def validate_semver(version: str) -> str:
     try:
         parsed = parse_version(version)
@@ -572,22 +785,25 @@ def bump_version(version: str, bump_type: str) -> str:
         raise ValueError(f"Invalid bump type: {bump_type}")
 
 
-def get_current_version(checks: List[VersionExtractor]) -> Optional[str]:
-    """Get the current consensus version from all files."""
-    versions_found = set()
-    errors = []
-
+def collect_versions(
+    checks: List[VersionExtractor],
+) -> Tuple[set, List[str]]:
+    """Collect distinct versions and parse errors across all files. No console output."""
+    versions: set = set()
+    errors: List[str] = []
     for check in checks:
         if check.check_file_exists():
             try:
-                version = check.get_version()
-                versions_found.add(version)
+                versions.add(check.get_version())
             except VersionNotPresent:
                 pass  # file exists but has no version configured; skip
             except Exception as e:
-                errors.append(f"{check.name}: {e}")
+                errors.append(f"{check.label}: {e}")
+    return versions, errors
 
-    # Report parsing errors
+
+def report_version_problems(versions: set, errors: List[str]) -> None:
+    """Print parse warnings and version-mismatch errors from collect_versions()."""
     if errors:
         console.print(
             f"[{STYLE_WARNING}]Warning: Failed to parse version from some files:[/{STYLE_WARNING}]"
@@ -595,21 +811,25 @@ def get_current_version(checks: List[VersionExtractor]) -> Optional[str]:
         for error in errors:
             console.print(f"  [{STYLE_MUTED}]• {error}[/{STYLE_MUTED}]")
 
-    if len(versions_found) == 1:
-        return list(versions_found)[0]
-    elif len(versions_found) > 1:
-        console.print(
-            f"[{STYLE_ERROR}]Error: Multiple versions found: {', '.join(sorted(versions_found))}[/{STYLE_ERROR}]"
-        )
+    if len(versions) > 1:
         console.print(
             f"[{STYLE_INFO}]Tip:[/{STYLE_INFO}] use --update-version X.Y.Z to set a single version across all files."
         )
-        return None
-    else:
+        console.print(
+            f"[{STYLE_ERROR}]Error: version mismatch — multiple versions found: "
+            f"{', '.join(sorted(versions))}[/{STYLE_ERROR}]"
+        )
+    elif not versions:
         console.print(
             f"[{STYLE_ERROR}]Error: No version found in any files.[/{STYLE_ERROR}]"
         )
-        return None
+
+
+def get_current_version(checks: List[VersionExtractor]) -> Optional[str]:
+    """Consensus version across all files, reporting any problems."""
+    versions, errors = collect_versions(checks)
+    report_version_problems(versions, errors)
+    return next(iter(versions)) if len(versions) == 1 else None
 
 
 def infer_change_type(
@@ -927,9 +1147,10 @@ def create_backups(file_paths: List[Path]) -> Dict[Path, Path]:
     backups = {}
     temp_dir = Path(tempfile.mkdtemp(prefix="release_backup_"))
 
-    for file_path in file_paths:
+    # Index-prefix the name so files sharing a basename don't collide.
+    for index, file_path in enumerate(file_paths):
         if file_path.exists():
-            backup_path = temp_dir / file_path.name
+            backup_path = temp_dir / f"{index:04d}_{file_path.name}"
             shutil.copy2(file_path, backup_path)
             backups[file_path] = backup_path
 
@@ -984,16 +1205,16 @@ def list_version_files(checks: List[VersionExtractor]) -> None:
             else f"[{STYLE_ERROR}]✗[/{STYLE_ERROR}]"
         )
         file_type = check.__class__.__name__.replace("VersionExtractor", "")
-        table.add_row(check.name, str(check.file_path), exists, file_type)
+        table.add_row(check.label, str(check.file_path), exists, file_type)
 
     console.print(table)
     sys.exit(0)
 
 
-def handle_check_version(checks: List[VersionExtractor], args) -> int:
+def handle_check_version(checks: List[VersionExtractor], args) -> bool:
     """Handle the --check-version command.
 
-    Returns the exit code.
+    Returns True if all files agree on one version, False otherwise.
     """
     results = []
     versions_found = set()
@@ -1006,7 +1227,7 @@ def handle_check_version(checks: List[VersionExtractor], args) -> int:
 
     for check in checks:
         result = {
-            "file": check.name,
+            "file": check.label,
             "version": None,
             "status": "Unknown",
             "message": "",
@@ -1039,13 +1260,14 @@ def handle_check_version(checks: List[VersionExtractor], args) -> int:
         consensus_version = "MISMATCH"
 
     if args.output_format == "json":
+        consistent = not errors and len(versions_found) == 1
         out_payload = {
             "consensus_version": consensus_version,
             "files": results,
-            "consistent": not errors and len(versions_found) == 1,
+            "consistent": consistent,
         }
         print(json.dumps(out_payload, indent=2))
-        return 1 if errors else 0
+        return consistent
 
     # Standard Rich table output
     table = Table(title="Version Check Summary", box=box.ROUNDED)
@@ -1074,7 +1296,7 @@ def handle_check_version(checks: List[VersionExtractor], args) -> int:
             ):
                 version_display = f"[{STYLE_SUCCESS}]{res['version']}[/{STYLE_SUCCESS}]"
             elif consensus_version == "MISMATCH":
-                version_display = f"[{STYLE_WARNING}]{res['version']}[/{STYLE_WARNING}]"
+                version_display = f"[{STYLE_ERROR}]{res['version']}[/{STYLE_ERROR}]"
 
         table.add_row(res["file"], version_display, status_style, res["message"])
 
@@ -1101,10 +1323,10 @@ def handle_check_version(checks: List[VersionExtractor], args) -> int:
     if errors:
         if len(versions_found) > 1:
             console.print(
-                f"\n[{STYLE_ERROR_STRONG}]MISMATCH:[/{STYLE_ERROR_STRONG}] Found conflicting versions: {', '.join(sorted(versions_found))}"
+                f"\n[{STYLE_INFO}]Tip:[/{STYLE_INFO}] use --update-version X.Y.Z to set a single version across all files."
             )
             console.print(
-                f"[{STYLE_INFO}]Tip:[/{STYLE_INFO}] use --update-version X.Y.Z to set a single version across all files."
+                f"[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] version mismatch — conflicting versions: {', '.join(sorted(versions_found))}"
             )
         elif tag_check_failed:
             if not tag_format_is_valid:
@@ -1117,20 +1339,20 @@ def handle_check_version(checks: List[VersionExtractor], args) -> int:
                 )
         else:
             console.print(
-                f"\n[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] Errors encountered (parsing errors)."
+                f"\n[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] parsing errors encountered."
             )
-        return 1
+        return False
     elif not versions_found:
         console.print(
             f"\n[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] No version files found in {args.root}."
         )
-        return 1
+        return False
     else:
         if not args.short:
             console.print(
                 f"\n[{STYLE_SUCCESS_STRONG}]SUCCESS:[/{STYLE_SUCCESS_STRONG}] All files match version [{STYLE_SUCCESS}]{consensus_version}[/{STYLE_SUCCESS}]."
             )
-        return 0
+        return True
 
 
 def perform_version_updates(
@@ -1153,7 +1375,7 @@ def perform_version_updates(
             try:
                 if dry_run:
                     curr = check.get_version()
-                    dry_run_rows.append((check.name, curr, target_version))
+                    dry_run_rows.append((check.label, curr, target_version))
                 else:
                     try:
                         old_version = check.get_version()
@@ -1162,20 +1384,20 @@ def perform_version_updates(
                     except Exception:
                         old_version = "?"
                     check.update_version(target_version)
-                    dry_run_rows.append((check.name, old_version, target_version))
+                    dry_run_rows.append((check.label, old_version, target_version))
                     line = Text()
-                    line.append(f"  {check.name:<22}", style="cyan")
+                    line.append(f"  {check.label:<28}", style="cyan")
                     line.append(old_version, style=STYLE_OLD_VALUE)
                     line.append("  →  ", style="dim")
                     line.append(target_version, style=STYLE_NEW_VALUE)
                     console.print(line)
-                updated_files.append(check.name)
+                updated_files.append(check.label)
                 updated_file_paths.append(str(check.file_path))
             except VersionNotPresent:
                 pass  # file exists but has no version configured; skip
             except Exception as e:
                 console.print(
-                    f"[{STYLE_ERROR}]Failed to update {check.name}: {e}[/{STYLE_ERROR}]"
+                    f"[{STYLE_ERROR}]Failed to update {check.label}: {e}[/{STYLE_ERROR}]"
                 )
                 if not dry_run:
                     failed = True
@@ -1198,14 +1420,14 @@ def show_dry_run_panel(
     console.print(f"  [dim]{'─' * 44}[/dim]")
     for name, old, new in dry_run_rows:
         line = Text()
-        line.append(f"  {name:<22}", style="cyan")
+        line.append(f"  {name:<28}", style="cyan")
         line.append(old, style=STYLE_OLD_VALUE)
         line.append("  →  ", style="dim")
         line.append(new, style=STYLE_NEW_VALUE)
         console.print(line)
     if pixi_lock_would_update:
         line = Text()
-        line.append(f"  {'pixi.lock':<22}", style="cyan")
+        line.append(f"  {'pixi.lock':<28}", style="cyan")
         line.append("regenerated via pixi list", style="dim")
         console.print(line)
 
@@ -1224,7 +1446,7 @@ def show_result_panel(
     """Display a polished summary of completed version updates."""
     if pixi_lock_updated:
         line = Text()
-        line.append(f"  {'pixi.lock':<22}", style="cyan")
+        line.append(f"  {'pixi.lock':<28}", style="cyan")
         line.append("regenerated via pixi list", style="dim")
         console.print(line)
     console.print()
@@ -1382,16 +1604,7 @@ def main():
             )
             sys.exit(1)
 
-    checks: List[VersionExtractor] = [
-        XmlVersionExtractor(root_dir / "package.xml"),
-        TomlVersionExtractor(root_dir / "pyproject.toml", ["project", "version"]),
-        ChangelogVersionExtractor(root_dir / "CHANGELOG.md", r""),
-        TomlVersionExtractor(root_dir / "pixi.toml", ["workspace", "version"]),
-        YamlVersionExtractor(root_dir / "CITATION.cff", ["version"]),
-        CMakeListsVersionExtractor(root_dir / "CMakeLists.txt"),
-        DebianChangelogVersionExtractor(root_dir / "debian/changelog"),
-        ConanfileVersionExtractor(root_dir / "conanfile.py"),
-    ]
+    checks: List[VersionExtractor] = collect_version_checks(root_dir)
 
     if args.list_files:
         if args.output_format == "json":
@@ -1399,7 +1612,7 @@ def main():
             for check in checks:
                 files_list.append(
                     {
-                        "name": check.name,
+                        "name": check.label,
                         "path": str(check.file_path),
                         "exists": check.check_file_exists(),
                         "type": check.__class__.__name__.replace(
@@ -1413,14 +1626,15 @@ def main():
         sys.exit(0)
 
     if args.check_version:
-        sys.exit(handle_check_version(checks, args))
+        sys.exit(0 if handle_check_version(checks, args) else 1)
 
     current_version = None
     new_version_str = None
 
     if args.update_version:
         new_version_str = args.update_version
-        current_version = get_current_version(checks)
+        versions, _ = collect_versions(checks)
+        current_version = next(iter(versions)) if len(versions) == 1 else None
         if not args.dry_run:
             console.print(
                 f"[{STYLE_INFO}]Updating versions to {new_version_str} in {root_dir}...[/{STYLE_INFO}]"

--- a/v2/scripts/jrl_release.py
+++ b/v2/scripts/jrl_release.py
@@ -602,7 +602,7 @@ def get_current_version(checks: List[VersionExtractor]) -> Optional[str]:
             f"[{STYLE_ERROR}]Error: Multiple versions found: {', '.join(sorted(versions_found))}[/{STYLE_ERROR}]"
         )
         console.print(
-            f"[{STYLE_WARNING}]Please run --check-version first to resolve conflicts.[/{STYLE_WARNING}]"
+            f"[{STYLE_INFO}]Tip:[/{STYLE_INFO}] use --update-version X.Y.Z to set a single version across all files."
         )
         return None
     else:
@@ -1101,7 +1101,10 @@ def handle_check_version(checks: List[VersionExtractor], args) -> int:
     if errors:
         if len(versions_found) > 1:
             console.print(
-                f"\n[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] Found conflicting versions: {', '.join(sorted(versions_found))}"
+                f"\n[{STYLE_ERROR_STRONG}]MISMATCH:[/{STYLE_ERROR_STRONG}] Found conflicting versions: {', '.join(sorted(versions_found))}"
+            )
+            console.print(
+                f"[{STYLE_INFO}]Tip:[/{STYLE_INFO}] use --update-version X.Y.Z to set a single version across all files."
             )
         elif tag_check_failed:
             if not tag_format_is_valid:

--- a/v2/scripts/test_jrl_release.py
+++ b/v2/scripts/test_jrl_release.py
@@ -199,6 +199,66 @@ def project_dir(
     return tmp_path
 
 
+@pytest.fixture
+def meta_package_dir(tmp_path):
+    """Create a meta-package repository: root aggregator + nested ROS packages."""
+    changelog_content = """# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2024-01-15
+
+### Added
+- Initial release
+"""
+    (tmp_path / "CHANGELOG.md").write_text(changelog_content, encoding="utf-8")
+    (tmp_path / "CMakeLists.txt").write_text(
+        "cmake_minimum_required(VERSION 3.10)\n"
+        "project(meta_pkg VERSION 1.0.0)\n"
+        "add_subdirectory(pkg_a)\n"
+        "add_subdirectory(pkg_b)\n",
+        encoding="utf-8",
+    )
+
+    for package_name in ("pkg_a", "pkg_b"):
+        package_dir = tmp_path / package_name
+        package_dir.mkdir()
+        (package_dir / "package.xml").write_text(
+            f"""<?xml version="1.0"?>
+<package format="2">
+  <name>{package_name}</name>
+  <version>1.0.0</version>
+  <description>{package_name}</description>
+</package>
+""",
+            encoding="utf-8",
+        )
+        (package_dir / "CMakeLists.txt").write_text(
+            f"cmake_minimum_required(VERSION 3.10)\nproject({package_name} VERSION 1.0.0)\n",
+            encoding="utf-8",
+        )
+
+    return tmp_path
+
+
+@pytest.fixture
+def nested_packages_only_dir(tmp_path):
+    """Create a repository containing only nested ROS packages (no root files)."""
+    for package_name in ("pkg_a", "pkg_b"):
+        package_dir = tmp_path / package_name
+        package_dir.mkdir()
+        (package_dir / "package.xml").write_text(
+            f"<package><name>{package_name}</name><version>1.0.0</version></package>",
+            encoding="utf-8",
+        )
+        (package_dir / "CMakeLists.txt").write_text(
+            f"project({package_name} VERSION 1.0.0)\n",
+            encoding="utf-8",
+        )
+
+    return tmp_path
+
+
 # ============================================================================
 # TEST VersionExtractor Base Class
 # ============================================================================
@@ -1214,6 +1274,8 @@ def test_cli_check_version_mismatch(tmp_path, mocker, capsys):
         release.main()
 
     assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "--update-version" in captured.out
 
 
 def test_cli_check_version_json_output(project_dir, mocker, capsys):
@@ -1251,6 +1313,57 @@ def test_cli_check_version_short_output(project_dir, mocker, capsys):
 
     captured = capsys.readouterr()
     assert captured.out.strip() == "1.0.0"
+
+
+def test_cli_check_version_short_output_nested_packages_only(
+    nested_packages_only_dir, mocker, capsys
+):
+    """--check-version --short works when only nested packages carry the version."""
+    mocker.patch(
+        "sys.argv",
+        [
+            "jrl_release.py",
+            "--root",
+            str(nested_packages_only_dir),
+            "--check-version",
+            "--short",
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        release.main()
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "1.0.0"
+
+
+def test_cli_update_version_meta_package(meta_package_dir, mocker):
+    """--update-version updates the root and every nested ROS package."""
+    mocker.patch(
+        "sys.argv",
+        [
+            "jrl_release.py",
+            "--root",
+            str(meta_package_dir),
+            "--update-version",
+            "2.3.4",
+        ],
+    )
+
+    try:
+        release.main()
+    except SystemExit as e:
+        assert e.code == 0
+
+    for package_name in ("pkg_a", "pkg_b"):
+        package_xml = (meta_package_dir / package_name / "package.xml").read_text()
+        cmake_lists = (meta_package_dir / package_name / "CMakeLists.txt").read_text()
+        assert "<version>2.3.4</version>" in package_xml
+        assert "VERSION 2.3.4" in cmake_lists
+
+    # Root files updated too.
+    assert "VERSION 2.3.4" in (meta_package_dir / "CMakeLists.txt").read_text()
+    assert "## [2.3.4] - " in (meta_package_dir / "CHANGELOG.md").read_text()
 
 
 def test_cli_list_files(project_dir, mocker, capsys):
@@ -1427,7 +1540,7 @@ def test_cli_git_commit_and_tag(project_dir, mocker, capsys):
     mock_run.side_effect = [
         (True, ""),  # rev-parse --git-dir (commit check)
         (True, "M file.txt"),  # status --porcelain
-        (True, ""),  # add -u
+        (True, ""),  # add <files_to_stage>
         (True, "committed"),  # commit
         (True, ""),  # rev-parse --git-dir (tag check)
         (False, ""),  # rev-parse v1.0.1 (tag doesn't exist)
@@ -1529,6 +1642,206 @@ def test_list_version_files_display(project_dir):
         assert "pyproject.toml" in output
     finally:
         release.console = old_console
+
+
+# ============================================================================
+# TEST Meta-package Discovery
+# ============================================================================
+
+
+def test_discover_package_roots_meta_package(meta_package_dir):
+    """discover_package_roots returns only the nested package roots (root excluded)."""
+    roots = release.discover_package_roots(meta_package_dir)
+
+    assert roots == [
+        meta_package_dir / "pkg_a",
+        meta_package_dir / "pkg_b",
+    ]
+
+
+def test_discover_package_roots_single_package_excludes_root(project_dir):
+    """A single package at the root yields no *nested* roots."""
+    assert release.discover_package_roots(project_dir) == []
+
+
+def test_discover_package_roots_skips_hidden_dirs(tmp_path):
+    """package.xml under any hidden dir (.git, .pixi, .cache) is skipped, no git needed."""
+    for hidden in (".git", ".pixi", ".cache"):
+        pkg = tmp_path / hidden / "pkg_x"
+        pkg.mkdir(parents=True)
+        (pkg / "package.xml").write_text(
+            "<package><version>1.0.0</version></package>", encoding="utf-8"
+        )
+
+    real_pkg = tmp_path / "pkg_a"
+    real_pkg.mkdir()
+    (real_pkg / "package.xml").write_text(
+        "<package><version>1.0.0</version></package>", encoding="utf-8"
+    )
+
+    assert release.discover_package_roots(tmp_path) == [real_pkg]
+
+
+def test_discover_package_roots_hidden_check_relative_to_root(tmp_path):
+    """A hidden component *above* the root must not exclude everything below it."""
+    root = tmp_path / ".hidden_parent" / "repo"
+    pkg = root / "pkg_a"
+    pkg.mkdir(parents=True)
+    (pkg / "package.xml").write_text(
+        "<package><version>1.0.0</version></package>", encoding="utf-8"
+    )
+
+    assert release.discover_package_roots(root) == [pkg]
+
+
+def test_discover_package_roots_no_builtin_noise_filter(tmp_path):
+    """Without a .gitignore, non-hidden dirs like build/ are NOT skipped (user's call)."""
+    build_pkg = tmp_path / "build" / "pkg_x"
+    build_pkg.mkdir(parents=True)
+    (build_pkg / "package.xml").write_text(
+        "<package><version>1.0.0</version></package>", encoding="utf-8"
+    )
+
+    assert release.discover_package_roots(tmp_path) == [build_pkg]
+
+
+def _init_git_repo(root):
+    """Initialize a minimal git repo for check-ignore tests."""
+    for cmd in (
+        ["init"],
+        ["config", "user.email", "t@t"],
+        ["config", "user.name", "t"],
+    ):
+        subprocess.run(["git"] + cmd, cwd=root, check=True, capture_output=True)
+
+
+def test_discover_package_roots_respects_gitignore(tmp_path):
+    """A package.xml under a git-ignored directory is skipped during discovery."""
+    _init_git_repo(tmp_path)
+    (tmp_path / ".gitignore").write_text("vendored/\n", encoding="utf-8")
+
+    ignored_pkg = tmp_path / "vendored" / "dep"
+    ignored_pkg.mkdir(parents=True)
+    (ignored_pkg / "package.xml").write_text(
+        "<package><version>9.9.9</version></package>", encoding="utf-8"
+    )
+
+    real_pkg = tmp_path / "pkg_a"
+    real_pkg.mkdir()
+    (real_pkg / "package.xml").write_text(
+        "<package><version>1.0.0</version></package>", encoding="utf-8"
+    )
+
+    assert release.discover_package_roots(tmp_path) == [real_pkg]
+
+
+def test_discover_package_roots_skips_submodules(tmp_path):
+    """A package.xml inside a git submodule (per .gitmodules) is skipped."""
+    _init_git_repo(tmp_path)
+    (tmp_path / ".gitmodules").write_text(
+        '[submodule "dep"]\n\tpath = ext/dep\n\turl = https://example.com/dep.git\n',
+        encoding="utf-8",
+    )
+
+    submodule_pkg = tmp_path / "ext" / "dep"
+    submodule_pkg.mkdir(parents=True)
+    (submodule_pkg / "package.xml").write_text(
+        "<package><version>9.9.9</version></package>", encoding="utf-8"
+    )
+
+    real_pkg = tmp_path / "pkg_a"
+    real_pkg.mkdir()
+    (real_pkg / "package.xml").write_text(
+        "<package><version>1.0.0</version></package>", encoding="utf-8"
+    )
+
+    assert release.discover_package_roots(tmp_path) == [real_pkg]
+
+
+def test_git_submodule_dirs_empty_without_gitmodules(tmp_path):
+    """No .gitmodules (or no repo) yields no submodule dirs."""
+    assert release.git_submodule_dirs(tmp_path) == set()
+    _init_git_repo(tmp_path)
+    assert release.git_submodule_dirs(tmp_path) == set()
+
+
+def test_drop_git_ignored_noop_without_git(tmp_path):
+    """Outside a git repo, no paths are dropped."""
+    pkg = tmp_path / "pkg_a"
+    pkg.mkdir()
+    xml = pkg / "package.xml"
+    xml.write_text("<package><version>1.0.0</version></package>", encoding="utf-8")
+
+    assert release.drop_git_ignored(tmp_path, [xml]) == [xml]
+
+
+def test_collect_version_checks_single_package_unchanged(project_dir):
+    """Single-package repos yield exactly the seven base root checks."""
+    checks = release.collect_version_checks(project_dir)
+    check_paths = {check.file_path for check in checks}
+
+    assert check_paths == {
+        project_dir / "package.xml",
+        project_dir / "pyproject.toml",
+        project_dir / "CHANGELOG.md",
+        project_dir / "pixi.toml",
+        project_dir / "CITATION.cff",
+        project_dir / "CMakeLists.txt",
+        project_dir / "debian/changelog",
+        project_dir / "conanfile.py",
+    }
+
+
+def test_collect_version_checks_meta_package(meta_package_dir):
+    """Version checks are collected from the root and every nested package."""
+    checks = release.collect_version_checks(meta_package_dir)
+    check_paths = {check.file_path for check in checks}
+
+    # Root metadata + root CMakeLists (root CMake is version-managed).
+    assert meta_package_dir / "CHANGELOG.md" in check_paths
+    assert meta_package_dir / "CMakeLists.txt" in check_paths
+    # Nested packages.
+    assert meta_package_dir / "pkg_a" / "package.xml" in check_paths
+    assert meta_package_dir / "pkg_a" / "CMakeLists.txt" in check_paths
+    assert meta_package_dir / "pkg_b" / "package.xml" in check_paths
+    assert meta_package_dir / "pkg_b" / "CMakeLists.txt" in check_paths
+
+
+def test_collect_version_checks_labels_are_root_relative(meta_package_dir):
+    """Nested files with identical basenames get distinct, root-relative labels."""
+    checks = release.collect_version_checks(meta_package_dir)
+    labels = {check.label for check in checks}
+
+    # Root files keep their bare basename.
+    assert "CMakeLists.txt" in labels
+    # Nested files are disambiguated by their relative path.
+    assert str(Path("pkg_a") / "package.xml") in labels
+    assert str(Path("pkg_b") / "package.xml") in labels
+    assert str(Path("pkg_a") / "CMakeLists.txt") in labels
+
+
+def test_create_backups_nested_no_collision(tmp_path):
+    """Nested files sharing a basename get distinct backups (no clobbering)."""
+    (tmp_path / "pkg_a").mkdir()
+    (tmp_path / "pkg_b").mkdir()
+    a = tmp_path / "pkg_a" / "package.xml"
+    b = tmp_path / "pkg_b" / "package.xml"
+    a.write_text("<version>1.0.0</version>", encoding="utf-8")
+    b.write_text("<version>2.0.0</version>", encoding="utf-8")
+
+    backups = release.create_backups([a, b])
+
+    # Both originals are backed up to distinct files.
+    assert len(backups) == 2
+    assert len(set(backups.values())) == 2
+
+    # Corrupt the originals, then restore and confirm each got its own content.
+    a.write_text("CORRUPT", encoding="utf-8")
+    b.write_text("CORRUPT", encoding="utf-8")
+    release.restore_backups(backups)
+
+    assert a.read_text() == "<version>1.0.0</version>"
+    assert b.read_text() == "<version>2.0.0</version>"
 
 
 # ============================================================================


### PR DESCRIPTION
THis PR allows discovery of nested packages, like in ROS meta pkgs scenarios.

This adds a bit of complexity in order to ignore walking into ALL the files. So right now we limit to git repositories, avoid folders that starts with ".", mais ignore `.gitignore` files/folders with `git ls-files`, which happens to be very helpful. 