### PR TITLE
jrl_release: add --check-version --check-tag vx.y.z

### DIFF
--- a/v2/scripts/jrl_release.py
+++ b/v2/scripts/jrl_release.py
@@ -1066,11 +1066,34 @@ def handle_check_version(checks: List[VersionExtractor], args) -> int:
     if args.short and consensus_version and consensus_version != "MISMATCH":
         print(consensus_version)
 
+    tag_check_failed = False
+    tag_format_is_valid = False
+    if hasattr(args, "check_tag") and args.check_tag:
+        if not args.check_tag.startswith("v"):
+            tag_check_failed = True
+            errors = True
+        else:
+            tag_version = args.check_tag.lstrip("v")
+            if consensus_version and consensus_version != "MISMATCH":
+                if consensus_version != tag_version:
+                    tag_check_failed = True
+                    tag_format_is_valid = True
+                    errors = True
+
     if errors:
         if len(versions_found) > 1:
             console.print(
                 f"\n[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] Found conflicting versions: {', '.join(sorted(versions_found))}"
             )
+        elif tag_check_failed:
+            if not tag_format_is_valid:
+                console.print(
+                    f"\n[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] Tag version ({args.check_tag}) format is invalid. It should start with 'v' and be a semantic version."
+                )
+            else:
+                console.print(
+                    f"\n[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] Tag version ({args.check_tag.lstrip('v')}) does not match consensus version ({consensus_version})."
+                )
         else:
             console.print(
                 f"\n[{STYLE_ERROR_STRONG}]FAILURE:[/{STYLE_ERROR_STRONG}] Errors encountered (parsing errors)."
@@ -1306,6 +1329,12 @@ def main():
         help="Bump the project version.",
     )
 
+    parser.add_argument(
+        "--check-tag",
+        type=str,
+        help="Check that the consensus version matches the given tag (e.g., v2.15.0). Only meaningful with --check-version.",
+    )
+
     args = parser.parse_args()
     root_dir = args.root
 
@@ -1315,6 +1344,9 @@ def main():
         console = Console(file=sys.stderr)
     else:
         console = Console()
+
+    if args.check_tag and not args.check_version:
+        parser.error("--check-tag requires --check-version")
 
     if args.update_version:
         try:

--- a/v2/scripts/test_jrl_release.py
+++ b/v2/scripts/test_jrl_release.py
@@ -1134,6 +1134,41 @@ def test_cli_check_version_success(project_dir, mocker, capsys):
     assert "SUCCESS" in captured.out or "1.0.0" in captured.out
 
 
+@pytest.mark.parametrize(
+    "tag,expected_code,expected_text",
+    [
+        ("v1.0.0", 0, "SUCCESS"),
+        ("v1.2.0", 1, "FAIL"),
+        ("1.0.0", 1, "FAIL"),
+    ],
+)
+def test_cli_check_version_check_tag(
+    project_dir, mocker, capsys, tag, expected_code, expected_text
+):
+    """Test CLI --check-version --check-tag with various tags."""
+    mocker.patch(
+        "sys.argv",
+        [
+            "jrl_release.py",
+            "--root",
+            str(project_dir),
+            "--check-version",
+            "--check-tag",
+            tag,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        release.main()
+
+    if expected_code == 0:
+        assert exc_info.value.code == 0
+    else:
+        assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert expected_text in captured.out or tag in captured.out
+
+
 def test_cli_check_version_mismatch(tmp_path, mocker, capsys):
     """Test CLI --check-version with version mismatch."""
     (tmp_path / "package.xml").write_text("<version>1.0.0</version>")


### PR DESCRIPTION
Adds a `--check-tag vx.y.z` to use with `--check-version` to ensure both that:
- version numbers are consistent
- they match an externally provided tag

This is mainly useful for CI, where we have checks that want to ensure that the pushed tag `vX.Y.Z` matches the version numbers in the project.

Output:
- Invalid tag format: `jrl-release.py --check-version --check-tag 2.1.5`
```
Checking versions in /home/arnaud/devel/mc-rtc-nix/workspace/jrl-cmakemodules...
                  Version Check Summary
╭──────────────────┬─────────┬─────────┬────────────────╮
│ File             │ Version │ Status  │ Details        │
├──────────────────┼─────────┼─────────┼────────────────┤
│ package.xml      │ 2.1.0   │  Found  │                │
│ pyproject.toml   │ -       │ Missing │ File not found │
│ CHANGELOG.md     │ 2.1.0   │  Found  │                │
│ pixi.toml        │ 2.1.0   │  Found  │                │
│ CITATION.cff     │ -       │ Missing │ File not found │
│ CMakeLists.txt   │ 2.1.0   │  Found  │                │
│ debian/changelog │ -       │ Missing │ File not found │
╰──────────────────┴─────────┴─────────┴────────────────╯

FAILURE: Tag version (2.1.5) format is invalid. It should start with 'v' and be a semantic version.
```

- Invalid tag version `jrl-release.py -- --check-version --check-tag v2.1.5`

```
Checking versions in /home/arnaud/devel/mc-rtc-nix/workspace/jrl-cmakemodules...
                  Version Check Summary
╭──────────────────┬─────────┬─────────┬────────────────╮
│ File             │ Version │ Status  │ Details        │
├──────────────────┼─────────┼─────────┼────────────────┤
│ package.xml      │ 2.1.0   │  Found  │                │
│ pyproject.toml   │ -       │ Missing │ File not found │
│ CHANGELOG.md     │ 2.1.0   │  Found  │                │
│ pixi.toml        │ 2.1.0   │  Found  │                │
│ CITATION.cff     │ -       │ Missing │ File not found │
│ CMakeLists.txt   │ 2.1.0   │  Found  │                │
│ debian/changelog │ -       │ Missing │ File not found │
╰──────────────────┴─────────┴─────────┴────────────────╯

FAILURE: Tag version (2.1.5) does not match consensus version (2.1.0).
```


For github actions:
```yaml
    - name: Install uv
      uses: astral-sh/setup-uv@v8.3.2

    - name: Install jrl-cmakemodules-scripts
      run: |
        uv tool install jrl-cmakemodules-scripts --from git+https://github.com/jrl-umi3218/jrl-cmakemodules.git#subdirectory=v2/scripts

    - name: Check version coherency
      shell: bash
      run: |
        set -x
        export VERSION=`echo ${{ github.ref }} | sed -e 's@refs/tags/@@'`
        # todo add conanfile.py support
        jrl-release --check-version --check-tag $VERSION
      if: startsWith(github.ref, 'refs/tags/')
   ```
