### PR TITLE
jrl_cmakemodules_scripts: add package.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- jrl_release: add package.xml
+
 ## [2.2.4] - 2026-08-07
 
 - fix pypi release for 2.2.4

--- a/v2/scripts/package.xml
+++ b/v2/scripts/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>jrl_cmakemodules_scripts</name>
+  <version>2.2.4</version>
+  <description>Release scripting tools for JRL CMake modules</description>
+  <url type="website">https://github.com/jrl-umi3218/jrl-cmakemodules</url>
+
+  <maintainer email="guilhem.saurel@laas.fr">Guilhem Saurel</maintainer>
+  <author>Antoine Hoarau</author>
+
+  <license>BSD-3-Clause</license>
+
+  <depend>python3-tomlkit</depend>
+  <depend>python3-ruamel.yaml</depend>
+  <depend>python3-rich</depend>
+  <depend>python3-packaging</depend>
+  <!-- TODO: not in debian/ubuntu/rosdep
+   <depend>python3-cmake-parser</depend>
+  -->
+
+   <test_depend>python3-pytest</test_depend>
+   <test_depend>python3-pytest-mock</test_depend>
+   <test_depend>python3-pytest-mock</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>


### PR DESCRIPTION
to avoid forgetting to bump version in v2/scripts/pyproject.toml:
```
$ ./v2/scripts/jrl_release.py --dry-run --bump patch
╭─ Version Change (patch) ─╮
│ 2.2.4 → 2.2.5            │
╰──────────────────────────╯

Dry run — no files were modified

  Files
  ────────────────────────────────────────────
  package.xml                 2.2.4  →  2.2.5
  CHANGELOG.md                2.2.4  →  2.2.5
  pixi.toml                   2.2.4  →  2.2.5
  CMakeLists.txt              2.2.4  →  2.2.5
  v2/scripts/package.xml      2.2.4  →  2.2.5
  v2/scripts/pyproject.toml   2.2.4  →  2.2.5
  pixi.lock                   regenerated via pixi list
```